### PR TITLE
proxy icon fix

### DIFF
--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -30,6 +30,16 @@
 	return self;
 }
 
+- (void)synchronizeWindowTitleWithDocumentName
+{
+    [super synchronizeWindowTitleWithDocumentName];
+
+    // Point window proxy icon at project directory, not internal .git dir
+    NSString *workingDirectory = [self.repository workingDirectory];
+    [[self window] setRepresentedURL:[NSURL fileURLWithPath:workingDirectory
+                                                isDirectory:YES]];
+}
+
 - (void)windowWillClose:(NSNotification *)notification
 {
 	NSLog(@"Window will close!");


### PR DESCRIPTION
It's pretty rare you'd want to use the proxy icon to get to the .git
directory seeing as all document interactions such as open occur
at the higher level. (Bare repositories excepted.)

This should address laullon/gitx#106
