### PR TITLE
subject history collide

### DIFF
--- a/Classes/Views/PBGitRevisionCell.m
+++ b/Classes/Views/PBGitRevisionCell.m
@@ -218,8 +218,13 @@
 		lastRect = rect;
 		++index;
 	}
-	refRect->size.width -= lastRect.origin.x - refRect->origin.x + lastRect.size.width;
-	refRect->origin.x    = lastRect.origin.x + lastRect.size.width;
+
+    // Only update rect to account for drawn refs if necessary to push
+    // subsequent content to the right.
+    if (index > 0) {
+        refRect->size.width -= lastRect.origin.x - refRect->origin.x + lastRect.size.width;
+        refRect->origin.x    = lastRect.origin.x + lastRect.size.width;
+    }
 }
 
 - (void) drawWithFrame: (NSRect) rect inView:(NSView *)view


### PR DESCRIPTION
If the column for presenting refs is not wide enough to actually draw
any refs, the rectangle we started with that accounted for the history
lines already should not be adjusted with the rect(0,0,0,0).

In useful sized columns that zero rect would be updated as refs that can
be drawn are drawn ensuring the subject appears to the right.

This addresses gh-48
