### PR TITLE
Fix for retina macs

### DIFF
--- a/Classes/Controllers/PBRefController.m
+++ b/Classes/Controllers/PBRefController.m
@@ -314,7 +314,8 @@
 
 - (BOOL)tableView:(NSTableView *)tv writeRowsWithIndexes:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard*)pboard
 {
-	NSPoint location = [tv convertPointFromBase:[(PBCommitList *)tv mouseDownPoint]];
+    
+	NSPoint location = [(PBCommitList *)tv mouseDownPoint];
 	int row = [tv rowAtPoint:location];
 	int column = [tv columnAtPoint:location];
 	int subjectColumn = [tv columnWithIdentifier:@"SubjectColumn"];

--- a/Classes/PBCommitList.m
+++ b/Classes/PBCommitList.m
@@ -91,7 +91,7 @@
 
 - (void)mouseDown:(NSEvent *)theEvent
 {
-	mouseDownPoint = [[self window] mouseLocationOutsideOfEventStream];
+    mouseDownPoint = [self convertPoint:[theEvent locationInWindow] fromView:nil];
 	[super mouseDown:theEvent];
 }
 
@@ -100,7 +100,7 @@
 								   event:(NSEvent *)dragEvent
 								  offset:(NSPointPointer)dragImageOffset
 {
-	NSPoint location = [self convertPointFromBase:mouseDownPoint];
+	NSPoint location = mouseDownPoint;
 	int row = [self rowAtPoint:location];
 	int column = [self columnAtPoint:location];
 	PBGitRevisionCell *cell = (PBGitRevisionCell *)[self preparedCellAtColumn:column row:row];

--- a/Classes/Views/PBGitRevisionCell.m
+++ b/Classes/Views/PBGitRevisionCell.m
@@ -310,7 +310,7 @@
 	if (!contextMenuDelegate)
 		return [self menu];
 
-	int i = [self indexAtX:[view convertPointFromBase:[event locationInWindow]].x - rect.origin.x];
+	int i = [self indexAtX:[view convertPoint:[event locationInWindow] fromView:nil].x - rect.origin.x];
 
 	id ref = nil;
 	if (i >= 0)


### PR DESCRIPTION
This commit accounts for double pixels when dragging labels, and right clicking
