### PR TITLE
don't crash if .git is not a directory Fixes #26

### DIFF
--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -145,7 +145,7 @@
 
 - (void) commitWithVerification:(BOOL) doVerify
 {
-	if ([[NSFileManager defaultManager] fileExistsAtPath:[repository.fileURL.path stringByAppendingPathComponent:@"MERGE_HEAD"]]) {
+	if ([[NSFileManager defaultManager] fileExistsAtPath:[repository.gitURL.path stringByAppendingPathComponent:@"MERGE_HEAD"]]) {
 		[[repository windowController] showMessageSheet:@"Cannot commit merges" infoText:@"GitX cannot commit merges yet. Please commit your changes from the command line."];
 		return;
 	}

--- a/Classes/git/PBGitIndex.m
+++ b/Classes/git/PBGitIndex.m
@@ -163,7 +163,7 @@ NSString *PBGitIndexOperationFailed = @"PBGitIndexOperationFailed";
 		[commitSubject appendString:[commitMessage substringToIndex:newLine.location]];
 	
 	NSString *commitMessageFile;
-	commitMessageFile = [repository.fileURL.path stringByAppendingPathComponent:@"COMMIT_EDITMSG"];
+	commitMessageFile = [repository.gitURL.path stringByAppendingPathComponent:@"COMMIT_EDITMSG"];
 	
 	[commitMessage writeToFile:commitMessageFile atomically:YES encoding:NSUTF8StringEncoding error:nil];
 

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -79,6 +79,8 @@ static NSString * PBStringFromBranchFilterType(PBGitXBranchFilterType type) {
 - (BOOL) deleteRemote:(PBGitRef *)ref;
 - (BOOL) deleteRef:(PBGitRef *)ref;
 
+- (NSURL *) gitURL ;
+
 - (NSFileHandle*) handleForCommand:(NSString*) cmd DEPRECATED;
 - (NSFileHandle*) handleForArguments:(NSArray*) args DEPRECATED;
 - (NSFileHandle *) handleInWorkDirForArguments:(NSArray *)args DEPRECATED;

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -60,7 +60,7 @@
 	NSError* repoInitError;
 	GTRepository* objgRepo = [[GTRepository alloc] initWithURL:repositoryURL error:&repoInitError];
 	if (objgRepo != NULL) {
-		NSURL* repoPath = [objgRepo fileURL];
+		NSURL* repoPath = [objgRepo gitDirectoryURL];
 		return repoPath;
 	}
 	return nil;
@@ -117,12 +117,14 @@
 		return NO;
 	}
 
-	[self setFileURL:gitDirURL];
 	[self setup];
   watcher = [[PBGitRepositoryWatcher alloc] initWithRepository:self];
 	return YES;
 }
 
+- (NSURL *) gitURL {
+    return self.gtRepo.gitDirectoryURL;
+}
 - (void) setup
 {
 	self->configuration = self.gtRepo.configuration;
@@ -149,7 +151,9 @@
 		return nil;
 
 	self = [self init];
-	[self setFileURL: gitDirURL];
+    
+    //TODO: IS THIS CORRECT???
+	[self setFileURL: path];
 
 	[self setup];
 	
@@ -176,8 +180,7 @@
 	return NO;
 }
 
-// The fileURL the document keeps is to the .git dir, but that’s pretty
-// useless for display in the window title bar, so we show the directory above
+// The fileURL the document keeps is to the working dir
 - (NSString *) displayName
 {
 	if (![[PBGitRef refFromString:[[self headRef] simpleRef]] type])
@@ -540,8 +543,10 @@
 {
 	if ([self.fileURL.path hasSuffix:@"/.git"])
 		return [self.fileURL.path substringToIndex:[self.fileURL.path length] - 5];
-	else if ([[self outputForCommand:@"rev-parse --is-inside-work-tree"] isEqualToString:@"true"])
-		return [PBGitBinary path];
+    else
+        return self.fileURL.path;
+//	else if ([[self outputForCommand:@"rev-parse --is-inside-work-tree"] isEqualToString:@"true"])
+//		return [PBGitBinary path];
 	
 	return nil;
 }
@@ -1060,7 +1065,7 @@
 
 - (NSFileHandle*) handleForArguments:(NSArray *)args
 {
-	NSString* gitDirArg = [@"--git-dir=" stringByAppendingString:self.fileURL.path];
+	NSString* gitDirArg = [@"--git-dir=" stringByAppendingString:self.gitURL.path];
 	NSMutableArray* arguments =  [NSMutableArray arrayWithObject: gitDirArg];
 	[arguments addObjectsFromArray: args];
 	return [PBEasyPipe handleForCommand:[PBGitBinary path] withArgs:arguments];
@@ -1068,7 +1073,7 @@
 
 - (NSFileHandle*) handleInWorkDirForArguments:(NSArray *)args
 {
-	NSString* gitDirArg = [@"--git-dir=" stringByAppendingString:self.fileURL.path];
+	NSString* gitDirArg = [@"--git-dir=" stringByAppendingString:self.gitURL.path];
 	NSMutableArray* arguments =  [NSMutableArray arrayWithObject: gitDirArg];
 	[arguments addObjectsFromArray: args];
 	return [PBEasyPipe handleForCommand:[PBGitBinary path] withArgs:arguments inDir:[self workingDirectory]];
@@ -1138,13 +1143,13 @@
 
 - (BOOL)executeHook:(NSString *)name withArgs:(NSArray *)arguments output:(NSString **)output
 {
-	NSString *hookPath = [[[[self fileURL] path] stringByAppendingPathComponent:@"hooks"] stringByAppendingPathComponent:name];
+	NSString *hookPath = [[[[self gitURL] path] stringByAppendingPathComponent:@"hooks"] stringByAppendingPathComponent:name];
 	if (![[NSFileManager defaultManager] isExecutableFileAtPath:hookPath])
 		return TRUE;
 
 	NSDictionary *info = [NSDictionary dictionaryWithObjectsAndKeys:
-		[self fileURL].path, @"GIT_DIR",
-		[[self fileURL].path stringByAppendingPathComponent:@"index"], @"GIT_INDEX_FILE",
+		[self gitURL].path, @"GIT_DIR",
+		[[self gitURL].path stringByAppendingPathComponent:@"index"], @"GIT_INDEX_FILE",
 		nil
 	];
 

--- a/Classes/git/PBGitRepositoryWatcher.m
+++ b/Classes/git/PBGitRepositoryWatcher.m
@@ -53,7 +53,7 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 	repository = theRepository;
 	FSEventStreamContext context = {0, (__bridge void *)(self), NULL, NULL, NULL};
 
-	NSString *path = [repository isBareRepository] ? repository.fileURL.path : [repository workingDirectory];
+	NSString *path = [repository.gitURL path];
 	NSArray *paths = [NSArray arrayWithObject: path];
 
 	// Create and activate event stream
@@ -81,7 +81,7 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 }
 
 - (BOOL) _indexChanged {
-    NSDate *newTouchDate = [self _fileModificationDateAtPath:[repository.fileURL.path stringByAppendingPathComponent:@"index"]];
+    NSDate *newTouchDate = [self _fileModificationDateAtPath:[repository.gitURL.path stringByAppendingPathComponent:@"index"]];
 	if (![newTouchDate isEqual:indexTouchDate]) {
 		indexTouchDate = newTouchDate;
 		return YES;
@@ -92,7 +92,7 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 
 - (BOOL) _gitDirectoryChanged {
 
-	for (NSURL* fileURL in [[NSFileManager defaultManager] contentsOfDirectoryAtURL:repository.fileURL
+	for (NSURL* fileURL in [[NSFileManager defaultManager] contentsOfDirectoryAtURL:repository.gitURL
 														 includingPropertiesForKeys:[NSArray arrayWithObject:NSURLContentModificationDateKey]
 																			options:0
 						
@@ -127,7 +127,7 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 		event |= PBGitRepositoryWatcherEventTypeIndex;
 	}
 	
-	NSString* ourRepo_ns = repository.fileURL.path;
+	NSString* ourRepo_ns = repository.gitURL.path;
 	// libgit2 API results for directories end with a '/'
 	if (![ourRepo_ns hasSuffix:@"/"])
 		ourRepo_ns = [NSString stringWithFormat:@"%@/", ourRepo_ns];
@@ -141,7 +141,7 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
     
 	for (PBGitRepositoryWatcherEventPath *eventPath in eventPaths) {
 		// .git dir
-		if ([[eventPath.path stringByStandardizingPath] isEqual:[repository.fileURL.path stringByStandardizingPath]]) {
+		if ([[eventPath.path stringByStandardizingPath] isEqual:[repository.gitURL.path stringByStandardizingPath]]) {
 			// ignore changes to lock files
 			if ([eventPath.path hasSuffix:@".lock"])
 			{
@@ -157,7 +157,7 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 		}
 
 		// subdirs of .git dir
-		else if ([eventPath.path rangeOfString:repository.fileURL.path].location != NSNotFound) {
+		else if ([eventPath.path rangeOfString:repository.gitURL.path].location != NSNotFound) {
 			// ignore changes to lock files
 			if ([eventPath.path hasSuffix:@".lock"])
 			{


### PR DESCRIPTION
The latest git provides a mechanism for storing
the .git directory outside of the working tree.

This commit removes the ".git" from the concept of
"fileURL" and adds a gitURL property that may
exist elsewhere on the filesystem.
