### PR TITLE
Fixed broken .cpp highlighting.

### DIFF
--- a/html/views/fileview/fileview.js
+++ b/html/views/fileview/fileview.js
@@ -83,7 +83,7 @@ var showFile = function(txt, fileName) {
     "h": "cpp",
     "hh": "cpp",
     "hpp": "cpp",
-    "cpp": "h++",
+    "h++": "cpp",
     "c": "cpp"
   }
   var brush = "objc";


### PR DESCRIPTION
It was returning `h++` non-existent highlighter for `cpp` extension, while it was supposed to return `cpp` for `h++` extension.

It is amazing nonone noticed this problem before ;)
