### PR TITLE
Consistent source views

### DIFF
--- a/html/css/shThemeGitX.css
+++ b/html/css/shThemeGitX.css
@@ -34,12 +34,18 @@
   color: black !important;
 }
 .syntaxhighlighter .gutter {
-  color: #afafaf !important;
+  border: 1px solid #dddddd !important;
+  padding: 5px 0 !important;
+  background-color: #ececec !important;
+}
+.syntaxhighlighter table td.gutter .line {
+  text-align: right !important;
+  padding: 0 2px 0 2px !important;
+  min-width: 20px;
 }
 .syntaxhighlighter .gutter .line {
-  border-right: 3px solid #6ce26c !important;
-	display: block !important;
-	width: 30px !important;
+  background-color: #ececec !important;
+  color: #a9a9a9 !important;
 }
 .syntaxhighlighter .gutter .line.highlighted {
   background-color: #6ce26c !important;

--- a/html/css/shThemeGitX.css
+++ b/html/css/shThemeGitX.css
@@ -16,7 +16,7 @@
  */
 .syntaxhighlighter {
   background-color: white !important;
-  font: 11px "Menlo" !important;
+  font: 1em "Menlo" !important;
 }
 .syntaxhighlighter .line.alt1 {
   background-color: white !important;

--- a/html/views/blame/blame.css
+++ b/html/views/blame/blame.css
@@ -24,6 +24,11 @@ p{
 	white-space: nowrap;
 }
 
+pre{
+  font-size: 1em;
+  font-family: Menlo, Consolas, 'Bitstream Vera Sans Mono', 'Courier New', Courier, monospace;
+}
+
 tr.block.l3 p.summary,
 tr.block.l2 p.summary,
 tr.block.l1 p.summary{
@@ -50,8 +55,14 @@ table.blocks{
 	width: 100% !important;
 }
 
+table.blocks tr td:nth-of-type(1) {
+  background-color: #ececec !important;
+	border-right: 1px solid #c9c9c9 !important;
+}
+
 table.blocks tr td:nth-of-type(2) {
 	width: 100% !important;
+  padding-left: 1em !important;
 }
 
 table.blocks tr.block td:nth-of-type(1){

--- a/html/views/fileview/fileview.js
+++ b/html/views/fileview/fileview.js
@@ -86,13 +86,13 @@ var showFile = function(txt, fileName) {
     "cpp": "h++",
     "c": "cpp"
   }
-  var brush = "objc";
+
   var suffix = "";
   if (fileName && fileName != '') {
     suffix = fileName.substr(fileName.lastIndexOf('.') + 1);
   }
   
-  brush = suffix_map[suffix];
+  var brush = suffix_map[suffix] ? suffix_map[suffix] : "plain";
   
   $("source").innerHTML="<pre class='first-line: 1;brush: " + brush + "'>" + txt + "</pre>";
 

--- a/html/views/fileview/source.css
+++ b/html/views/fileview/source.css
@@ -1,0 +1,4 @@
+body, html, #source {
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
Purpose of this branch/mods is to provide consistency for various source views:
1. Use same font size and family 1em across all diff, source, blame
2. Use same gutter style across diff, source, blame
3. Fallback to `plain` for unknown extensions in source view

![](http://www.nanoant.com/screenshots/gitx-1.png)
![](http://www.nanoant.com/screenshots/gitx-2.png)
![](http://www.nanoant.com/screenshots/gitx-3.png)
