### PR TITLE
Prevent note refs from appearing in the history view

### DIFF
--- a/Classes/git/PBGitRevSpecifier.m
+++ b/Classes/git/PBGitRevSpecifier.m
@@ -60,7 +60,8 @@
 
 + (PBGitRevSpecifier *)allBranchesRevSpec
 {
-	return [[PBGitRevSpecifier alloc] initWithParameters:[NSArray arrayWithObject:@"--all"] description:@"All branches"];
+    // Using --all here would include refs like refs/notes/commits, which probably isn't what we want.
+	return [[PBGitRevSpecifier alloc] initWithParameters:[NSArray arrayWithObjects:@"--branches", @"--remotes", @"--tags", nil] description:@"All branches"];
 }
 
 + (PBGitRevSpecifier *)localBranchesRevSpec


### PR DESCRIPTION
This doesn't go so far as to actually show the note with the commit that it's attached to, but will at least prevent refs/notes/commits & co from appearing in the history window.  WDYT?
