### PR TITLE
git-svn revision support

### DIFF
--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -76,6 +76,12 @@
 	else
 		[repository lazyReload];
 
+    if (![repository hasSVNRemote])
+    {
+        // Remove the SVN revision table column for repositories with no SVN remote configured
+        [commitList removeTableColumn:[commitList tableColumnWithIdentifier:@"GitSVNRevision"]];
+    }
+
 	// Set a sort descriptor for the subject column in the history list, as
 	// It can't be sorted by default (because it's bound to a PBGitCommit)
 	[[commitList tableColumnWithIdentifier:@"SubjectColumn"] setSortDescriptorPrototype:[[NSSortDescriptor alloc] initWithKey:@"subject" ascending:YES]];

--- a/Classes/git/PBGitCommit.h
+++ b/Classes/git/PBGitCommit.h
@@ -26,6 +26,7 @@ extern NSString * const kGitXCommitType;
 	NSString *_patch;
 	NSArray *parents;
 	NSString *realSHA;
+    NSString *SVNRevision;
 
 	int timestamp;
 	char sign;
@@ -52,6 +53,7 @@ extern NSString * const kGitXCommitType;
 @property (copy) NSString* subject;
 @property (copy) NSString* author;
 @property (copy) NSString *committer;
+@property (copy) NSString *SVNRevision;
 @property  NSArray *parents;
 
 @property (assign) int timestamp;

--- a/Classes/git/PBGitCommit.m
+++ b/Classes/git/PBGitCommit.m
@@ -16,7 +16,7 @@ NSString * const kGitXCommitType = @"commit";
 
 @implementation PBGitCommit
 
-@synthesize repository, subject, timestamp, author, sign, lineInfo;
+@synthesize repository, subject, timestamp, author, sign, lineInfo, SVNRevision;
 @synthesize sha;
 @synthesize parents;
 @synthesize committer;

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -106,6 +106,8 @@ static NSString * PBStringFromBranchFilterType(PBGitXBranchFilterType type) {
 - (BOOL)isBareRepository;
 + (BOOL)isBareRepository:(NSURL*)repositoryURL;
 
+- (BOOL)hasSVNRemote;
++ (BOOL)hasSVNRemote:(NSURL*)repositoryURL;
 
 - (void) reloadRefs;
 - (void) lazyReload;

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -56,6 +56,32 @@
 	return [PBGitRepository isBareRepository:[self fileURL]];
 }
 
++ (BOOL) hasSVNRemote: (NSURL *)url
+{
+    // ObjectiveGit doesn't give us the machinery to determine whether there's an SVN remote
+    // defined; so let's just find out ourselves...
+    
+    NSError* pError;
+    GTRepository* gitRepo = [[GTRepository alloc] initWithURL:url error:&pError];
+    
+    if (gitRepo)
+    {
+        NSURL    *configURL = [NSURL URLWithString:@".git/config" relativeToURL:url];
+        NSString *gitConfig = [NSString stringWithContentsOfURL:configURL encoding:NSUTF8StringEncoding error:&pError];
+        
+        if ([gitConfig rangeOfString:@"svn-remote"].location != NSNotFound) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+- (BOOL) hasSVNRemote
+{
+    return [PBGitRepository hasSVNRemote:[self fileURL]];
+}
+
 // NSFileWrapper is broken and doesn't work when called on a directory containing a large number of directories and files.
 //because of this it is safer to implement readFromURL than readFromFileWrapper.
 //Because NSFileManager does not attempt to recursively open all directories and file when fileExistsAtPath is called

--- a/Classes/git/PBGitRevList.mm
+++ b/Classes/git/PBGitRevList.mm
@@ -206,15 +206,18 @@ using namespace std;
 			[newCommit setAuthor:[NSString stringWithCString:author.c_str() encoding:encoding]];
 			[newCommit setCommitter:[NSString stringWithCString:committer.c_str() encoding:encoding]];
             
-            // get the git-svn-id from the message
-            NSString *string = [NSString stringWithCString:message.c_str() encoding:encoding];
-            NSArray *matches = [regex matchesInString:string options:0 range:NSMakeRange(0, [string length])];
-            
-            for (NSTextCheckingResult *match in matches)
+            if ([repository hasSVNRemote])
             {
-                NSRange matchRange = [match rangeAtIndex:1];
-                NSString *matchString = [string substringWithRange:matchRange];
-                [newCommit setSVNRevision:matchString];
+                // get the git-svn-id from the message
+                NSString *string = [NSString stringWithCString:message.c_str() encoding:encoding];
+                NSArray *matches = [regex matchesInString:string options:0 range:NSMakeRange(0, [string length])];
+                
+                for (NSTextCheckingResult *match in matches)
+                {
+                    NSRange matchRange = [match rangeAtIndex:1];
+                    NSString *matchString = [string substringWithRange:matchRange];
+                    [newCommit setSVNRevision:matchString];
+                }
             }
             
 			[newCommit setTimestamp:time];

--- a/Classes/git/PBGitRevList.mm
+++ b/Classes/git/PBGitRevList.mm
@@ -105,7 +105,8 @@ using namespace std;
 		std::map<string, NSStringEncoding> encodingMap;
 		NSThread *currentThread = [NSThread currentThread];
 		
-		NSString *formatString = @"--pretty=format:%H\03%e\03%aN\03%cN\03%s\03%P\03%at";
+		NSString *formatString = @"--pretty=format:%H\03%e\03%aN\03%cN\03%s\03%b\03%P\03%at";
+
 		BOOL showSign = [rev hasLeftRight];
 		
 		if (showSign)
@@ -132,6 +133,10 @@ using namespace std;
 		__gnu_cxx::stdio_filebuf<char> buf(fd, std::ios::in);
 		std::istream stream(&buf);
 		
+        // Regular expression for pulling out the SVN revision from the git log
+        NSError *error = nil;
+        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^git-svn-id: .*@(\\d+) .*$" options:0 error:&error];
+        
 		int num = 0;
 		while (true) {
 			if ([currentThread isCancelled])
@@ -167,6 +172,9 @@ using namespace std;
 			
 			string subject;
 			getline(stream, subject, '\3');
+            
+            string message;
+            getline(stream, message, '\3');
 			
 			string parentString;
 			getline(stream, parentString, '\3');
@@ -197,6 +205,18 @@ using namespace std;
 			[newCommit setSubject:[NSString stringWithCString:subject.c_str() encoding:encoding]];
 			[newCommit setAuthor:[NSString stringWithCString:author.c_str() encoding:encoding]];
 			[newCommit setCommitter:[NSString stringWithCString:committer.c_str() encoding:encoding]];
+            
+            // get the git-svn-id from the message
+            NSString *string = [NSString stringWithCString:message.c_str() encoding:encoding];
+            NSArray *matches = [regex matchesInString:string options:0 range:NSMakeRange(0, [string length])];
+            
+            for (NSTextCheckingResult *match in matches)
+            {
+                NSRange matchRange = [match rangeAtIndex:1];
+                NSString *matchString = [string substringWithRange:matchRange];
+                [newCommit setSVNRevision:matchString];
+            }
+            
 			[newCommit setTimestamp:time];
 			
 			if (showSign)

--- a/Resources/XIBs/PBGitHistoryView.xib
+++ b/Resources/XIBs/PBGitHistoryView.xib
@@ -2,41 +2,41 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1060</int>
-		<string key="IBDocument.SystemVersion">11D50d</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2182</string>
-		<string key="IBDocument.AppKitVersion">1138.32</string>
-		<string key="IBDocument.HIToolboxVersion">568.00</string>
+		<string key="IBDocument.SystemVersion">12C60</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.34</string>
+		<string key="IBDocument.HIToolboxVersion">625.00</string>
 		<dictionary class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="com.apple.InterfaceBuilder.CocoaPlugin">2182</string>
-			<string key="com.apple.WebKitIBPlugin">1117</string>
+			<string key="com.apple.InterfaceBuilder.CocoaPlugin">3084</string>
+			<string key="com.apple.WebKitIBPlugin">2053</string>
 		</dictionary>
 		<array key="IBDocument.IntegratedClassDependencies">
-			<string>WebView</string>
-			<string>NSButton</string>
-			<string>NSCustomObject</string>
 			<string>NSArrayController</string>
-			<string>NSSplitView</string>
-			<string>NSTableView</string>
+			<string>NSBox</string>
+			<string>NSButton</string>
+			<string>NSButtonCell</string>
+			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
 			<string>NSDateFormatter</string>
+			<string>NSOutlineView</string>
+			<string>NSProgressIndicator</string>
+			<string>NSScrollView</string>
+			<string>NSScroller</string>
 			<string>NSSearchField</string>
-			<string>NSTextField</string>
 			<string>NSSearchFieldCell</string>
+			<string>NSSegmentedCell</string>
+			<string>NSSegmentedControl</string>
+			<string>NSSplitView</string>
+			<string>NSTabView</string>
+			<string>NSTabViewItem</string>
+			<string>NSTableColumn</string>
+			<string>NSTableHeaderView</string>
+			<string>NSTableView</string>
+			<string>NSTextField</string>
 			<string>NSTextFieldCell</string>
 			<string>NSTreeController</string>
-			<string>NSButtonCell</string>
-			<string>NSTableColumn</string>
-			<string>NSSegmentedControl</string>
-			<string>NSBox</string>
-			<string>NSOutlineView</string>
 			<string>NSView</string>
-			<string>NSScrollView</string>
-			<string>NSTabViewItem</string>
-			<string>NSProgressIndicator</string>
-			<string>NSSegmentedCell</string>
-			<string>NSScroller</string>
-			<string>NSTableHeaderView</string>
-			<string>NSTabView</string>
+			<string>WebView</string>
 		</array>
 		<array key="IBDocument.PluginDependencies">
 			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -123,9 +123,10 @@
 								<string key="NSFrame">{{267, 3}, {71, 25}}</string>
 								<reference key="NSSuperview" ref="172148644"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="923983319"/>
 								<bool key="NSEnabled">YES</bool>
 								<object class="NSSegmentedCell" key="NSCell" id="534046869">
-									<int key="NSCellFlags">-2080244224</int>
+									<int key="NSCellFlags">-2080374784</int>
 									<int key="NSCellFlags2">0</int>
 									<object class="NSFont" key="NSSupport" id="924107556">
 										<string key="NSName">LucidaGrande</string>
@@ -158,6 +159,7 @@
 									</array>
 									<int key="NSSegmentStyle">2</int>
 								</object>
+								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 							</object>
 							<object class="NSButton" id="258088911">
 								<reference key="NSNextResponder" ref="172148644"/>
@@ -165,14 +167,15 @@
 								<string key="NSFrame">{{206, 3}, {37, 25}}</string>
 								<reference key="NSSuperview" ref="172148644"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="802449565"/>
 								<bool key="NSEnabled">YES</bool>
 								<object class="NSButtonCell" key="NSCell" id="760195759">
-									<int key="NSCellFlags">-2080244224</int>
+									<int key="NSCellFlags">-2080374784</int>
 									<int key="NSCellFlags2">134217728</int>
 									<string key="NSContents">Rebase</string>
 									<reference key="NSSupport" ref="924107556"/>
 									<reference key="NSControlView" ref="258088911"/>
-									<int key="NSButtonFlags">-2033958657</int>
+									<int key="NSButtonFlags">-2033958912</int>
 									<int key="NSButtonFlags2">163</int>
 									<object class="NSCustomResource" key="NSNormalImage">
 										<string key="NSClassName">NSImage</string>
@@ -183,6 +186,7 @@
 									<int key="NSPeriodicDelay">400</int>
 									<int key="NSPeriodicInterval">75</int>
 								</object>
+								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 							</object>
 							<object class="NSButton" id="1006113529">
 								<reference key="NSNextResponder" ref="172148644"/>
@@ -190,14 +194,15 @@
 								<string key="NSFrame">{{161, 3}, {37, 25}}</string>
 								<reference key="NSSuperview" ref="172148644"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="258088911"/>
 								<bool key="NSEnabled">YES</bool>
 								<object class="NSButtonCell" key="NSCell" id="772225018">
-									<int key="NSCellFlags">-2080244224</int>
+									<int key="NSCellFlags">-2080374784</int>
 									<int key="NSCellFlags2">134217728</int>
 									<string key="NSContents">Cherry Pick</string>
 									<reference key="NSSupport" ref="924107556"/>
 									<reference key="NSControlView" ref="1006113529"/>
-									<int key="NSButtonFlags">-2033958657</int>
+									<int key="NSButtonFlags">-2033958912</int>
 									<int key="NSButtonFlags2">163</int>
 									<object class="NSCustomResource" key="NSNormalImage">
 										<string key="NSClassName">NSImage</string>
@@ -208,6 +213,7 @@
 									<int key="NSPeriodicDelay">400</int>
 									<int key="NSPeriodicInterval">75</int>
 								</object>
+								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 							</object>
 							<object class="NSButton" id="502319102">
 								<reference key="NSNextResponder" ref="172148644"/>
@@ -215,14 +221,15 @@
 								<string key="NSFrame">{{116, 3}, {37, 25}}</string>
 								<reference key="NSSuperview" ref="172148644"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="1006113529"/>
 								<bool key="NSEnabled">YES</bool>
 								<object class="NSButtonCell" key="NSCell" id="934102630">
-									<int key="NSCellFlags">-2080244224</int>
+									<int key="NSCellFlags">-2080374784</int>
 									<int key="NSCellFlags2">134217728</int>
 									<string key="NSContents">Merge</string>
 									<reference key="NSSupport" ref="924107556"/>
 									<reference key="NSControlView" ref="502319102"/>
-									<int key="NSButtonFlags">-2033958657</int>
+									<int key="NSButtonFlags">-2033958912</int>
 									<int key="NSButtonFlags2">163</int>
 									<object class="NSCustomResource" key="NSNormalImage">
 										<string key="NSClassName">NSImage</string>
@@ -233,6 +240,7 @@
 									<int key="NSPeriodicDelay">400</int>
 									<int key="NSPeriodicInterval">75</int>
 								</object>
+								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 							</object>
 							<object class="NSButton" id="107487665">
 								<reference key="NSNextResponder" ref="172148644"/>
@@ -240,14 +248,15 @@
 								<string key="NSFrame">{{55, 3}, {37, 25}}</string>
 								<reference key="NSSuperview" ref="172148644"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="502319102"/>
 								<bool key="NSEnabled">YES</bool>
 								<object class="NSButtonCell" key="NSCell" id="794901717">
-									<int key="NSCellFlags">-2080244224</int>
+									<int key="NSCellFlags">-2080374784</int>
 									<int key="NSCellFlags2">134217728</int>
 									<string key="NSContents">Create Tag</string>
 									<reference key="NSSupport" ref="924107556"/>
 									<reference key="NSControlView" ref="107487665"/>
-									<int key="NSButtonFlags">-2033958657</int>
+									<int key="NSButtonFlags">-2033958912</int>
 									<int key="NSButtonFlags2">163</int>
 									<object class="NSCustomResource" key="NSNormalImage">
 										<string key="NSClassName">NSImage</string>
@@ -258,6 +267,7 @@
 									<int key="NSPeriodicDelay">400</int>
 									<int key="NSPeriodicInterval">75</int>
 								</object>
+								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 							</object>
 							<object class="NSButton" id="1051155594">
 								<reference key="NSNextResponder" ref="172148644"/>
@@ -265,14 +275,15 @@
 								<string key="NSFrame">{{10, 3}, {37, 25}}</string>
 								<reference key="NSSuperview" ref="172148644"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="107487665"/>
 								<bool key="NSEnabled">YES</bool>
 								<object class="NSButtonCell" key="NSCell" id="870128015">
-									<int key="NSCellFlags">-2080244224</int>
+									<int key="NSCellFlags">-2080374784</int>
 									<int key="NSCellFlags2">134217728</int>
 									<string key="NSContents">Create Branch</string>
 									<reference key="NSSupport" ref="924107556"/>
 									<reference key="NSControlView" ref="1051155594"/>
-									<int key="NSButtonFlags">-2033958657</int>
+									<int key="NSButtonFlags">-2033958912</int>
 									<int key="NSButtonFlags2">163</int>
 									<object class="NSCustomResource" key="NSNormalImage">
 										<string key="NSClassName">NSImage</string>
@@ -283,6 +294,7 @@
 									<int key="NSPeriodicDelay">400</int>
 									<int key="NSPeriodicInterval">75</int>
 								</object>
+								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 							</object>
 							<object class="NSBox" id="923983319">
 								<reference key="NSNextResponder" ref="172148644"/>
@@ -290,9 +302,10 @@
 								<string key="NSFrame">{{0, -2}, {955, 5}}</string>
 								<reference key="NSSuperview" ref="172148644"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="202620420"/>
 								<string key="NSOffsets">{0, 0}</string>
 								<object class="NSTextFieldCell" key="NSTitleCell">
-									<int key="NSCellFlags">67239424</int>
+									<int key="NSCellFlags">67108864</int>
 									<int key="NSCellFlags2">0</int>
 									<string key="NSContents">Box</string>
 									<reference key="NSSupport" ref="924107556"/>
@@ -319,6 +332,7 @@
 						<string key="NSFrame">{{0, 404}, {955, 30}}</string>
 						<reference key="NSSuperview" ref="319362431"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="1051155594"/>
 						<string key="NSClassName">PBGitGradientBarView</string>
 					</object>
 					<object class="NSSplitView" id="202620420">
@@ -335,9 +349,10 @@
 										<string key="NSFrame">{{0, 144}, {955, 5}}</string>
 										<reference key="NSSuperview" ref="24227530"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="663765878"/>
 										<string key="NSOffsets">{0, 0}</string>
 										<object class="NSTextFieldCell" key="NSTitleCell">
-											<int key="NSCellFlags">67239424</int>
+											<int key="NSCellFlags">67108864</int>
 											<int key="NSCellFlags2">0</int>
 											<string key="NSContents">Box</string>
 											<reference key="NSSupport" ref="924107556"/>
@@ -363,16 +378,20 @@
 													<object class="NSTableView" id="254268962">
 														<reference key="NSNextResponder" ref="546023969"/>
 														<int key="NSvFlags">4352</int>
-														<string key="NSFrameSize">{955, 130}</string>
+														<string key="NSFrameSize">{991, 115}</string>
 														<reference key="NSSuperview" ref="546023969"/>
 														<reference key="NSWindow"/>
+														<reference key="NSNextKeyView" ref="452331733"/>
 														<bool key="NSEnabled">YES</bool>
+														<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+														<bool key="NSControlAllowsExpansionToolTips">YES</bool>
 														<object class="NSTableHeaderView" key="NSHeaderView" id="942510576">
 															<reference key="NSNextResponder" ref="906093892"/>
 															<int key="NSvFlags">256</int>
-															<string key="NSFrameSize">{955, 17}</string>
+															<string key="NSFrameSize">{991, 17}</string>
 															<reference key="NSSuperview" ref="906093892"/>
 															<reference key="NSWindow"/>
+															<reference key="NSNextKeyView" ref="546023969"/>
 															<reference key="NSTableView" ref="254268962"/>
 														</object>
 														<object class="_NSCornerView" key="NSCornerView" id="688592759">
@@ -381,15 +400,16 @@
 															<string key="NSFrame">{{-26, 0}, {16, 17}}</string>
 															<reference key="NSSuperview" ref="663765878"/>
 															<reference key="NSWindow"/>
+															<reference key="NSNextKeyView" ref="906093892"/>
 														</object>
 														<array class="NSMutableArray" key="NSTableColumns">
 															<object class="NSTableColumn" id="760984800">
 																<string key="NSIdentifier">ShortSHAColumn</string>
-																<double key="NSWidth">73</double>
+																<double key="NSWidth">10</double>
 																<double key="NSMinWidth">10</double>
 																<double key="NSMaxWidth">73</double>
 																<object class="NSTableHeaderCell" key="NSHeaderCell">
-																	<int key="NSCellFlags">75628096</int>
+																	<int key="NSCellFlags">75497536</int>
 																	<int key="NSCellFlags2">2048</int>
 																	<string key="NSContents">Short SHA</string>
 																	<object class="NSFont" key="NSSupport" id="26">
@@ -414,7 +434,7 @@
 																	</object>
 																</object>
 																<object class="NSTextFieldCell" key="NSDataCell" id="493129112">
-																	<int key="NSCellFlags">338820672</int>
+																	<int key="NSCellFlags">338690112</int>
 																	<int key="NSCellFlags2">1024</int>
 																	<string key="NSContents"/>
 																	<object class="NSFont" key="NSSupport" id="475005913">
@@ -449,7 +469,7 @@
 																<double key="NSMinWidth">40</double>
 																<double key="NSMaxWidth">1000</double>
 																<object class="NSTableHeaderCell" key="NSHeaderCell">
-																	<int key="NSCellFlags">75628096</int>
+																	<int key="NSCellFlags">75497536</int>
 																	<int key="NSCellFlags2">2048</int>
 																	<string key="NSContents">Subject</string>
 																	<reference key="NSSupport" ref="26"/>
@@ -460,7 +480,7 @@
 																	<reference key="NSTextColor" ref="160578461"/>
 																</object>
 																<object class="NSTextFieldCell" key="NSDataCell" id="977219207">
-																	<int key="NSCellFlags">337772096</int>
+																	<int key="NSCellFlags">337641536</int>
 																	<int key="NSCellFlags2">2048</int>
 																	<string key="NSContents">Text Cell</string>
 																	<object class="NSFont" key="NSSupport" id="324419606">
@@ -482,7 +502,7 @@
 																<double key="NSMinWidth">40</double>
 																<double key="NSMaxWidth">1000</double>
 																<object class="NSTableHeaderCell" key="NSHeaderCell">
-																	<int key="NSCellFlags">75628096</int>
+																	<int key="NSCellFlags">75497536</int>
 																	<int key="NSCellFlags2">2048</int>
 																	<string key="NSContents">Author</string>
 																	<reference key="NSSupport" ref="26"/>
@@ -490,7 +510,7 @@
 																	<reference key="NSTextColor" ref="160578461"/>
 																</object>
 																<object class="NSTextFieldCell" key="NSDataCell" id="746918365">
-																	<int key="NSCellFlags">337772096</int>
+																	<int key="NSCellFlags">337641536</int>
 																	<int key="NSCellFlags2">2048</int>
 																	<string key="NSContents">Text Cell</string>
 																	<reference key="NSSupport" ref="324419606"/>
@@ -508,7 +528,7 @@
 																<double key="NSMinWidth">10</double>
 																<double key="NSMaxWidth">1000</double>
 																<object class="NSTableHeaderCell" key="NSHeaderCell">
-																	<int key="NSCellFlags">75628096</int>
+																	<int key="NSCellFlags">75497536</int>
 																	<int key="NSCellFlags2">2048</int>
 																	<string key="NSContents">Date</string>
 																	<reference key="NSSupport" ref="26"/>
@@ -516,7 +536,7 @@
 																	<reference key="NSTextColor" ref="160578461"/>
 																</object>
 																<object class="NSTextFieldCell" key="NSDataCell" id="853819733">
-																	<int key="NSCellFlags">337772096</int>
+																	<int key="NSCellFlags">337641536</int>
 																	<int key="NSCellFlags2">-2147481600</int>
 																	<string key="NSContents">Text Cell</string>
 																	<reference key="NSSupport" ref="324419606"/>
@@ -526,7 +546,7 @@
 																			<integer value="1040" key="formatterBehavior"/>
 																			<integer value="1" key="timeStyle"/>
 																		</dictionary>
-																		<string key="NS.format">MMMM d, y h:mm a</string>
+																		<string key="NS.format">d MMMM y HH:mm</string>
 																		<bool key="NS.natural">NO</bool>
 																	</object>
 																	<reference key="NSControlView" ref="254268962"/>
@@ -548,7 +568,7 @@
 																<double key="NSMinWidth">10</double>
 																<double key="NSMaxWidth">1000</double>
 																<object class="NSTableHeaderCell" key="NSHeaderCell">
-																	<int key="NSCellFlags">75628096</int>
+																	<int key="NSCellFlags">75497536</int>
 																	<int key="NSCellFlags2">2048</int>
 																	<string key="NSContents">Relative Date</string>
 																	<reference key="NSSupport" ref="26"/>
@@ -556,7 +576,7 @@
 																	<reference key="NSTextColor" ref="160578461"/>
 																</object>
 																<object class="NSTextFieldCell" key="NSDataCell" id="750921840">
-																	<int key="NSCellFlags">338820672</int>
+																	<int key="NSCellFlags">338690112</int>
 																	<int key="NSCellFlags2">1024</int>
 																	<string key="NSContents"/>
 																	<reference key="NSSupport" ref="324419606"/>
@@ -580,7 +600,7 @@
 																<double key="NSMinWidth">30</double>
 																<double key="NSMaxWidth">290</double>
 																<object class="NSTableHeaderCell" key="NSHeaderCell">
-																	<int key="NSCellFlags">75628096</int>
+																	<int key="NSCellFlags">75497536</int>
 																	<int key="NSCellFlags2">2048</int>
 																	<string key="NSContents">SHA</string>
 																	<reference key="NSSupport" ref="26"/>
@@ -588,7 +608,7 @@
 																	<reference key="NSTextColor" ref="160578461"/>
 																</object>
 																<object class="NSTextFieldCell" key="NSDataCell" id="671609291">
-																	<int key="NSCellFlags">338820672</int>
+																	<int key="NSCellFlags">338690112</int>
 																	<int key="NSCellFlags2">1024</int>
 																	<string key="NSContents">Text Cell</string>
 																	<reference key="NSSupport" ref="475005913"/>
@@ -600,6 +620,32 @@
 																<bool key="NSIsResizeable">YES</bool>
 																<reference key="NSTableView" ref="254268962"/>
 																<bool key="NSHidden">YES</bool>
+															</object>
+															<object class="NSTableColumn" id="670368861">
+																<double key="NSWidth">96</double>
+																<double key="NSMinWidth">10</double>
+																<double key="NSMaxWidth">3.4028234663852886e+38</double>
+																<object class="NSTableHeaderCell" key="NSHeaderCell">
+																	<int key="NSCellFlags">75497536</int>
+																	<int key="NSCellFlags2">2048</int>
+																	<string key="NSContents">Git SVN Revision</string>
+																	<reference key="NSSupport" ref="26"/>
+																	<reference key="NSBackgroundColor" ref="216155638"/>
+																	<reference key="NSTextColor" ref="160578461"/>
+																</object>
+																<object class="NSTextFieldCell" key="NSDataCell" id="742462198">
+																	<int key="NSCellFlags">337641536</int>
+																	<int key="NSCellFlags2">-2147481600</int>
+																	<string key="NSContents">Text Cell</string>
+																	<reference key="NSSupport" ref="324419606"/>
+																	<reference key="NSControlView" ref="254268962"/>
+																	<reference key="NSBackgroundColor" ref="827363147"/>
+																	<reference key="NSTextColor" ref="57062640"/>
+																</object>
+																<int key="NSResizingMask">3</int>
+																<bool key="NSIsResizeable">YES</bool>
+																<bool key="NSIsEditable">YES</bool>
+																<reference key="NSTableView" ref="254268962"/>
 															</object>
 														</array>
 														<double key="NSIntercellSpacingWidth">3</double>
@@ -615,7 +661,7 @@
 															</object>
 														</object>
 														<double key="NSRowHeight">17</double>
-														<int key="NSTvFlags">-750780416</int>
+														<int key="NSTvFlags">-748683264</int>
 														<reference key="NSDelegate"/>
 														<reference key="NSDataSource"/>
 														<string key="NSAutosaveName">CommitView</string>
@@ -627,7 +673,7 @@
 														<int key="NSTableViewGroupRowStyle">1</int>
 													</object>
 												</array>
-												<string key="NSFrame">{{0, 17}, {955, 130}}</string>
+												<string key="NSFrame">{{0, 17}, {955, 115}}</string>
 												<reference key="NSSuperview" ref="663765878"/>
 												<reference key="NSWindow"/>
 												<reference key="NSNextKeyView" ref="254268962"/>
@@ -641,21 +687,25 @@
 												<string key="NSFrame">{{837, 17}, {15, 179}}</string>
 												<reference key="NSSuperview" ref="663765878"/>
 												<reference key="NSWindow"/>
+												<reference key="NSNextKeyView" ref="560436169"/>
+												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 												<reference key="NSTarget" ref="663765878"/>
 												<string key="NSAction">_doScroller:</string>
-												<double key="NSPercent">0.87603306770324707</double>
+												<double key="NSPercent">0.88461538461538458</double>
 											</object>
 											<object class="NSScroller" id="452331733">
 												<reference key="NSNextResponder" ref="663765878"/>
-												<int key="NSvFlags">-2147483392</int>
-												<string key="NSFrame">{{0, 123}, {852, 15}}</string>
+												<int key="NSvFlags">256</int>
+												<string key="NSFrame">{{0, 132}, {955, 15}}</string>
 												<reference key="NSSuperview" ref="663765878"/>
 												<reference key="NSWindow"/>
+												<reference key="NSNextKeyView" ref="152625445"/>
+												<bool key="NSEnabled">YES</bool>
+												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 												<int key="NSsFlags">1</int>
 												<reference key="NSTarget" ref="663765878"/>
 												<string key="NSAction">_doScroller:</string>
-												<double key="NSCurValue">0.19685863874345549</double>
-												<double key="NSPercent">0.99882769584655762</double>
+												<double key="NSPercent">0.96367305751765897</double>
 											</object>
 											<object class="NSClipView" id="906093892">
 												<reference key="NSNextResponder" ref="663765878"/>
@@ -676,14 +726,17 @@
 										<string key="NSFrameSize">{955, 147}</string>
 										<reference key="NSSuperview" ref="24227530"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="546023969"/>
-										<int key="NSsFlags">133680</int>
+										<reference key="NSNextKeyView" ref="688592759"/>
+										<int key="NSsFlags">133808</int>
 										<reference key="NSVScroller" ref="152625445"/>
 										<reference key="NSHScroller" ref="452331733"/>
 										<reference key="NSContentView" ref="546023969"/>
 										<reference key="NSHeaderClipView" ref="906093892"/>
 										<reference key="NSCornerView" ref="688592759"/>
 										<bytes key="NSScrollAmts">QSAAAEEgAABBmAAAQZgAAA</bytes>
+										<double key="NSMinMagnification">0.25</double>
+										<double key="NSMaxMagnification">4</double>
+										<double key="NSMagnification">1</double>
 									</object>
 									<object class="NSCustomView" id="428755155">
 										<reference key="NSNextResponder" ref="24227530"/>
@@ -692,10 +745,10 @@
 											<object class="NSProgressIndicator" id="354339555">
 												<reference key="NSNextResponder" ref="428755155"/>
 												<int key="NSvFlags">-2147482359</int>
-												<object class="NSPSMatrix" key="NSDrawMatrix"/>
 												<string key="NSFrame">{{740, 3}, {16, 16}}</string>
 												<reference key="NSSuperview" ref="428755155"/>
 												<reference key="NSWindow"/>
+												<reference key="NSNextKeyView" ref="354285291"/>
 												<int key="NSpiFlags">20746</int>
 												<double key="NSMaxValue">100</double>
 											</object>
@@ -705,9 +758,10 @@
 												<string key="NSFrame">{{765, 2}, {180, 19}}</string>
 												<reference key="NSSuperview" ref="428755155"/>
 												<reference key="NSWindow"/>
+												<reference key="NSNextKeyView" ref="147470634"/>
 												<bool key="NSEnabled">YES</bool>
 												<object class="NSSearchFieldCell" key="NSCell" id="1022125543">
-													<int key="NSCellFlags">343014976</int>
+													<int key="NSCellFlags">342884416</int>
 													<int key="NSCellFlags2">268567552</int>
 													<reference key="NSSupport" ref="26"/>
 													<reference key="NSControlView" ref="354285291"/>
@@ -716,20 +770,20 @@
 													<reference key="NSBackgroundColor" ref="870781813"/>
 													<reference key="NSTextColor" ref="57062640"/>
 													<object class="NSButtonCell" key="NSSearchButtonCell">
-														<int key="NSCellFlags">130560</int>
+														<int key="NSCellFlags">0</int>
 														<int key="NSCellFlags2">0</int>
 														<string key="NSContents">search</string>
 														<reference key="NSControlView" ref="354285291"/>
 														<string key="NSAction">_searchFieldSearch:</string>
 														<reference key="NSTarget" ref="1022125543"/>
-														<int key="NSButtonFlags">138690815</int>
+														<int key="NSButtonFlags">138690560</int>
 														<int key="NSButtonFlags2">0</int>
 														<string key="NSKeyEquivalent"/>
 														<int key="NSPeriodicDelay">400</int>
 														<int key="NSPeriodicInterval">75</int>
 													</object>
 													<object class="NSButtonCell" key="NSCancelButtonCell">
-														<int key="NSCellFlags">130560</int>
+														<int key="NSCellFlags">0</int>
 														<int key="NSCellFlags2">0</int>
 														<string key="NSContents">clear</string>
 														<array class="NSMutableArray" key="NSAccessibilityOverriddenAttributes">
@@ -741,7 +795,7 @@
 														<reference key="NSControlView" ref="354285291"/>
 														<string key="NSAction">_searchFieldCancel:</string>
 														<reference key="NSTarget" ref="1022125543"/>
-														<int key="NSButtonFlags">138690815</int>
+														<int key="NSButtonFlags">138690560</int>
 														<int key="NSButtonFlags2">0</int>
 														<string key="NSKeyEquivalent"/>
 														<int key="NSPeriodicDelay">400</int>
@@ -750,6 +804,7 @@
 													<string key="NSRecentsAutosaveName">Recent History Searches</string>
 													<int key="NSMaximumRecents">255</int>
 												</object>
+												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 											</object>
 											<object class="NSSegmentedControl" id="563692607">
 												<reference key="NSNextResponder" ref="428755155"/>
@@ -757,9 +812,10 @@
 												<string key="NSFrame">{{714, 3}, {43, 18}}</string>
 												<reference key="NSSuperview" ref="428755155"/>
 												<reference key="NSWindow"/>
+												<reference key="NSNextKeyView" ref="354339555"/>
 												<bool key="NSEnabled">YES</bool>
 												<object class="NSSegmentedCell" key="NSCell" id="657989793">
-													<int key="NSCellFlags">67239424</int>
+													<int key="NSCellFlags">67108864</int>
 													<int key="NSCellFlags2">131072</int>
 													<object class="NSFont" key="NSSupport">
 														<string key="NSName">LucidaGrande</string>
@@ -786,6 +842,7 @@
 													<int key="NSTrackingMode">2</int>
 													<int key="NSSegmentStyle">3</int>
 												</object>
+												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 											</object>
 											<object class="NSTextField" id="627778713">
 												<reference key="NSNextResponder" ref="428755155"/>
@@ -793,9 +850,10 @@
 												<string key="NSFrame">{{630, 5}, {80, 14}}</string>
 												<reference key="NSSuperview" ref="428755155"/>
 												<reference key="NSWindow"/>
+												<reference key="NSNextKeyView" ref="563692607"/>
 												<bool key="NSEnabled">YES</bool>
 												<object class="NSTextFieldCell" key="NSCell" id="349876124">
-													<int key="NSCellFlags">68288064</int>
+													<int key="NSCellFlags">68157504</int>
 													<int key="NSCellFlags2">71435264</int>
 													<string key="NSContents"># of matches</string>
 													<reference key="NSSupport" ref="26"/>
@@ -808,6 +866,7 @@
 													</object>
 													<reference key="NSTextColor" ref="57062640"/>
 												</object>
+												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 											</object>
 											<object class="NSButton" id="832955200">
 												<reference key="NSNextResponder" ref="428755155"/>
@@ -815,10 +874,11 @@
 												<string key="NSFrame">{{49, 2}, {57, 17}}</string>
 												<reference key="NSSuperview" ref="428755155"/>
 												<reference key="NSWindow"/>
+												<reference key="NSNextKeyView" ref="1055854415"/>
 												<int key="NSTag">1</int>
 												<bool key="NSEnabled">YES</bool>
 												<object class="NSButtonCell" key="NSCell" id="819755658">
-													<int key="NSCellFlags">67239424</int>
+													<int key="NSCellFlags">67108864</int>
 													<int key="NSCellFlags2">134348800</int>
 													<string key="NSContents">Remote</string>
 													<object class="NSFont" key="NSSupport" id="689970718">
@@ -827,13 +887,14 @@
 														<int key="NSfFlags">16</int>
 													</object>
 													<reference key="NSControlView" ref="832955200"/>
-													<int key="NSButtonFlags">-1232846593</int>
+													<int key="NSButtonFlags">-1232846848</int>
 													<int key="NSButtonFlags2">173</int>
 													<string key="NSAlternateContents"/>
 													<string key="NSKeyEquivalent"/>
 													<int key="NSPeriodicDelay">400</int>
 													<int key="NSPeriodicInterval">75</int>
 												</object>
+												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 											</object>
 											<object class="NSButton" id="1055854415">
 												<reference key="NSNextResponder" ref="428755155"/>
@@ -841,21 +902,23 @@
 												<string key="NSFrame">{{114, 2}, {103, 17}}</string>
 												<reference key="NSSuperview" ref="428755155"/>
 												<reference key="NSWindow"/>
+												<reference key="NSNextKeyView" ref="627778713"/>
 												<int key="NSTag">2</int>
 												<bool key="NSEnabled">YES</bool>
 												<object class="NSButtonCell" key="NSCell" id="670683219">
-													<int key="NSCellFlags">67239424</int>
+													<int key="NSCellFlags">67108864</int>
 													<int key="NSCellFlags2">131072</int>
 													<string key="NSContents">Selected Branch</string>
 													<reference key="NSSupport" ref="689970718"/>
 													<reference key="NSControlView" ref="1055854415"/>
-													<int key="NSButtonFlags">-1232846593</int>
+													<int key="NSButtonFlags">-1232846848</int>
 													<int key="NSButtonFlags2">173</int>
 													<string key="NSAlternateContents"/>
 													<string key="NSKeyEquivalent"/>
 													<int key="NSPeriodicDelay">400</int>
 													<int key="NSPeriodicInterval">75</int>
 												</object>
+												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 											</object>
 											<object class="NSButton" id="884073279">
 												<reference key="NSNextResponder" ref="428755155"/>
@@ -863,31 +926,35 @@
 												<string key="NSFrame">{{11, 2}, {30, 17}}</string>
 												<reference key="NSSuperview" ref="428755155"/>
 												<reference key="NSWindow"/>
+												<reference key="NSNextKeyView" ref="832955200"/>
 												<bool key="NSEnabled">YES</bool>
 												<object class="NSButtonCell" key="NSCell" id="291056109">
-													<int key="NSCellFlags">67239424</int>
+													<int key="NSCellFlags">67108864</int>
 													<int key="NSCellFlags2">134348800</int>
 													<string key="NSContents">All</string>
 													<reference key="NSSupport" ref="689970718"/>
 													<reference key="NSControlView" ref="884073279"/>
-													<int key="NSButtonFlags">-1232846593</int>
+													<int key="NSButtonFlags">-1232846848</int>
 													<int key="NSButtonFlags2">173</int>
 													<string key="NSAlternateContents"/>
 													<string key="NSKeyEquivalent"/>
 													<int key="NSPeriodicDelay">400</int>
 													<int key="NSPeriodicInterval">75</int>
 												</object>
+												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 											</object>
 										</array>
 										<string key="NSFrame">{{0, 147}, {955, 24}}</string>
 										<reference key="NSSuperview" ref="24227530"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="884073279"/>
 										<string key="NSClassName">PBGitGradientBarView</string>
 									</object>
 								</array>
 								<string key="NSFrameSize">{955, 171}</string>
 								<reference key="NSSuperview" ref="202620420"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="428755155"/>
 								<string key="NSClassName">NSView</string>
 							</object>
 							<object class="NSCustomView" id="560436169">
@@ -900,6 +967,7 @@
 										<string key="NSFrameSize">{955, 233}</string>
 										<reference key="NSSuperview" ref="560436169"/>
 										<reference key="NSWindow"/>
+										<reference key="NSNextKeyView" ref="657042048"/>
 										<array class="NSMutableArray" key="NSTabViewItems">
 											<object class="NSTabViewItem" id="375889551">
 												<string key="NSIdentifier">1</string>
@@ -974,7 +1042,10 @@
 																					<string key="NSFrameSize">{216, 233}</string>
 																					<reference key="NSSuperview" ref="859661469"/>
 																					<reference key="NSWindow"/>
+																					<reference key="NSNextKeyView" ref="692013536"/>
 																					<bool key="NSEnabled">YES</bool>
+																					<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+																					<bool key="NSControlAllowsExpansionToolTips">YES</bool>
 																					<object class="_NSCornerView" key="NSCornerView">
 																						<nil key="NSNextResponder"/>
 																						<int key="NSvFlags">256</int>
@@ -986,7 +1057,7 @@
 																							<double key="NSMinWidth">16</double>
 																							<double key="NSMaxWidth">1000</double>
 																							<object class="NSTableHeaderCell" key="NSHeaderCell">
-																								<int key="NSCellFlags">75628096</int>
+																								<int key="NSCellFlags">75497536</int>
 																								<int key="NSCellFlags2">2048</int>
 																								<string key="NSContents"/>
 																								<reference key="NSSupport" ref="26"/>
@@ -997,7 +1068,7 @@
 																								<reference key="NSTextColor" ref="160578461"/>
 																							</object>
 																							<object class="NSTextFieldCell" key="NSDataCell" id="161807197">
-																								<int key="NSCellFlags">337772096</int>
+																								<int key="NSCellFlags">337641536</int>
 																								<int key="NSCellFlags2">2048</int>
 																								<string key="NSContents">Text Cell</string>
 																								<reference key="NSSupport" ref="924107556"/>
@@ -1040,6 +1111,8 @@
 																			<string key="NSFrame">{{217, 1}, {15, 233}}</string>
 																			<reference key="NSSuperview" ref="776605770"/>
 																			<reference key="NSWindow"/>
+																			<reference key="NSNextKeyView" ref="891500945"/>
+																			<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 																			<reference key="NSTarget" ref="776605770"/>
 																			<string key="NSAction">_doScroller:</string>
 																			<double key="NSPercent">0.99481862783432007</double>
@@ -1050,6 +1123,8 @@
 																			<string key="NSFrame">{{-100, -100}, {502, 15}}</string>
 																			<reference key="NSSuperview" ref="776605770"/>
 																			<reference key="NSWindow"/>
+																			<reference key="NSNextKeyView" ref="859661469"/>
+																			<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 																			<int key="NSsFlags">1</int>
 																			<reference key="NSTarget" ref="776605770"/>
 																			<string key="NSAction">_doScroller:</string>
@@ -1060,12 +1135,15 @@
 																	<string key="NSFrameSize">{233, 235}</string>
 																	<reference key="NSSuperview" ref="626906425"/>
 																	<reference key="NSWindow"/>
-																	<reference key="NSNextKeyView" ref="859661469"/>
+																	<reference key="NSNextKeyView" ref="471196443"/>
 																	<int key="NSsFlags">133138</int>
 																	<reference key="NSVScroller" ref="692013536"/>
 																	<reference key="NSHScroller" ref="471196443"/>
 																	<reference key="NSContentView" ref="859661469"/>
 																	<bytes key="NSScrollAmts">QSAAAEEgAABBmAAAQZgAAA</bytes>
+																	<double key="NSMinMagnification">0.25</double>
+																	<double key="NSMaxMagnification">4</double>
+																	<double key="NSMagnification">1</double>
 																</object>
 																<object class="NSCustomView" id="891500945">
 																	<reference key="NSNextResponder" ref="626906425"/>
@@ -1085,9 +1163,10 @@
 																							<string key="NSFrame">{{41, 1.5}, {29, 19}}</string>
 																							<reference key="NSSuperview" ref="951933530"/>
 																							<reference key="NSWindow"/>
+																							<reference key="NSNextKeyView" ref="979575572"/>
 																							<bool key="NSEnabled">YES</bool>
 																							<object class="NSButtonCell" key="NSCell" id="102056827">
-																								<int key="NSCellFlags">-2080244224</int>
+																								<int key="NSCellFlags">-2080374784</int>
 																								<int key="NSCellFlags2">134217728</int>
 																								<string key="NSContents">QuickLook</string>
 																								<object class="NSFont" key="NSSupport">
@@ -1096,7 +1175,7 @@
 																									<int key="NSfFlags">16</int>
 																								</object>
 																								<reference key="NSControlView" ref="16222431"/>
-																								<int key="NSButtonFlags">147079423</int>
+																								<int key="NSButtonFlags">147079168</int>
 																								<int key="NSButtonFlags2">173</int>
 																								<object class="NSCustomResource" key="NSNormalImage">
 																									<string key="NSClassName">NSImage</string>
@@ -1107,17 +1186,20 @@
 																								<int key="NSPeriodicDelay">400</int>
 																								<int key="NSPeriodicInterval">75</int>
 																							</object>
+																							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 																						</object>
 																					</array>
 																					<string key="NSFrame">{{639, 0}, {84, 24}}</string>
 																					<reference key="NSSuperview" ref="375746871"/>
 																					<reference key="NSWindow"/>
+																					<reference key="NSNextKeyView" ref="16222431"/>
 																					<string key="NSClassName">NSView</string>
 																				</object>
 																			</array>
 																			<string key="NSFrame">{{0, 211}, {723, 24}}</string>
 																			<reference key="NSSuperview" ref="891500945"/>
 																			<reference key="NSWindow"/>
+																			<reference key="NSNextKeyView" ref="951933530"/>
 																			<string key="NSClassName">MGScopeBar</string>
 																		</object>
 																		<object class="WebView" id="979575572">
@@ -1154,12 +1236,14 @@
 																	<string key="NSFrame">{{234, 0}, {723, 235}}</string>
 																	<reference key="NSSuperview" ref="626906425"/>
 																	<reference key="NSWindow"/>
+																	<reference key="NSNextKeyView" ref="375746871"/>
 																	<string key="NSClassName">NSView</string>
 																</object>
 															</array>
 															<string key="NSFrame">{{-1, -1}, {957, 235}}</string>
 															<reference key="NSSuperview" ref="657042048"/>
 															<reference key="NSWindow"/>
+															<reference key="NSNextKeyView" ref="776605770"/>
 															<bool key="NSIsVertical">YES</bool>
 															<int key="NSDividerStyle">2</int>
 														</object>
@@ -1167,6 +1251,7 @@
 													<string key="NSFrameSize">{955, 233}</string>
 													<reference key="NSSuperview" ref="135073984"/>
 													<reference key="NSWindow"/>
+													<reference key="NSNextKeyView" ref="626906425"/>
 												</object>
 												<string key="NSLabel">Tree</string>
 												<reference key="NSColor" ref="457244339"/>
@@ -1186,18 +1271,21 @@
 								<string key="NSFrame">{{0, 172}, {955, 233}}</string>
 								<reference key="NSSuperview" ref="202620420"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="135073984"/>
 								<string key="NSClassName">NSView</string>
 							</object>
 						</array>
 						<string key="NSFrameSize">{955, 405}</string>
 						<reference key="NSSuperview" ref="319362431"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="24227530"/>
 						<int key="NSDividerStyle">2</int>
 					</object>
 				</array>
 				<string key="NSFrameSize">{955, 434}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="172148644"/>
 				<string key="NSClassName">NSView</string>
 			</object>
 			<object class="NSCustomObject" id="892732705">
@@ -1996,6 +2084,30 @@
 					</object>
 					<int key="connectionID">485</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">value: arrangedObjects.SVNRevision</string>
+						<reference key="source" ref="670368861"/>
+						<reference key="destination" ref="391209158"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="670368861"/>
+							<reference key="NSDestination" ref="391209158"/>
+							<string key="NSLabel">value: arrangedObjects.SVNRevision</string>
+							<string key="NSBinding">value</string>
+							<string key="NSKeyPath">arrangedObjects.SVNRevision</string>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">498</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">contextMenuDelegate</string>
+						<reference key="source" ref="742462198"/>
+						<reference key="destination" ref="892732705"/>
+					</object>
+					<int key="connectionID">495</int>
+				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<array key="orderedObjects">
@@ -2121,6 +2233,7 @@
 							<reference ref="553429297"/>
 							<reference ref="760984800"/>
 							<reference ref="456964926"/>
+							<reference ref="670368861"/>
 						</array>
 						<reference key="parent" ref="663765878"/>
 						<string key="objectName">Commit List</string>
@@ -2573,6 +2686,20 @@
 						<reference key="object" ref="102056827"/>
 						<reference key="parent" ref="16222431"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">491</int>
+						<reference key="object" ref="670368861"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="742462198"/>
+						</array>
+						<reference key="parent" ref="254268962"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">493</int>
+						<reference key="object" ref="742462198"/>
+						<array class="NSMutableArray" key="children"/>
+						<reference key="parent" ref="670368861"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -2743,6 +2870,9 @@
 					</object>
 				</object>
 				<string key="49.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="491.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="493.CustomClassName">GitXTextFieldCell</string>
+				<string key="493.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="50.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="51.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="6.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -2754,7 +2884,7 @@
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">490</int>
+			<int key="maxID">498</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -2815,6 +2945,36 @@
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
 						<string key="minorKey">./Classes/GitXTextFieldCell.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">MGScopeBar</string>
+					<string key="superclassName">NSView</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">scopeButtonClicked:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">scopeButtonClicked:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">scopeButtonClicked:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">delegate</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">delegate</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0">
+							<string key="name">delegate</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/MGScopeBar.h</string>
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">

--- a/Resources/XIBs/PBGitHistoryView.xib
+++ b/Resources/XIBs/PBGitHistoryView.xib
@@ -2,10 +2,10 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1060</int>
-		<string key="IBDocument.SystemVersion">12C60</string>
+		<string key="IBDocument.SystemVersion">12D78</string>
 		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
+		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<dictionary class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="com.apple.InterfaceBuilder.CocoaPlugin">3084</string>
 			<string key="com.apple.WebKitIBPlugin">2053</string>
@@ -378,10 +378,10 @@
 													<object class="NSTableView" id="254268962">
 														<reference key="NSNextResponder" ref="546023969"/>
 														<int key="NSvFlags">4352</int>
-														<string key="NSFrameSize">{991, 115}</string>
+														<string key="NSFrameSize">{991, 130}</string>
 														<reference key="NSSuperview" ref="546023969"/>
 														<reference key="NSWindow"/>
-														<reference key="NSNextKeyView" ref="452331733"/>
+														<reference key="NSNextKeyView" ref="688592759"/>
 														<bool key="NSEnabled">YES</bool>
 														<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 														<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -395,11 +395,9 @@
 															<reference key="NSTableView" ref="254268962"/>
 														</object>
 														<object class="_NSCornerView" key="NSCornerView" id="688592759">
-															<reference key="NSNextResponder" ref="663765878"/>
+															<nil key="NSNextResponder"/>
 															<int key="NSvFlags">-2147483392</int>
 															<string key="NSFrame">{{-26, 0}, {16, 17}}</string>
-															<reference key="NSSuperview" ref="663765878"/>
-															<reference key="NSWindow"/>
 															<reference key="NSNextKeyView" ref="906093892"/>
 														</object>
 														<array class="NSMutableArray" key="NSTableColumns">
@@ -622,6 +620,7 @@
 																<bool key="NSHidden">YES</bool>
 															</object>
 															<object class="NSTableColumn" id="670368861">
+																<string key="NSIdentifier">GitSVNRevision</string>
 																<double key="NSWidth">96</double>
 																<double key="NSMinWidth">10</double>
 																<double key="NSMaxWidth">3.4028234663852886e+38</double>
@@ -673,7 +672,7 @@
 														<int key="NSTableViewGroupRowStyle">1</int>
 													</object>
 												</array>
-												<string key="NSFrame">{{0, 17}, {955, 115}}</string>
+												<string key="NSFrame">{{0, 17}, {955, 130}}</string>
 												<reference key="NSSuperview" ref="663765878"/>
 												<reference key="NSWindow"/>
 												<reference key="NSNextKeyView" ref="254268962"/>
@@ -696,7 +695,7 @@
 											<object class="NSScroller" id="452331733">
 												<reference key="NSNextResponder" ref="663765878"/>
 												<int key="NSvFlags">256</int>
-												<string key="NSFrame">{{0, 132}, {955, 15}}</string>
+												<string key="NSFrame">{{0, 131}, {955, 16}}</string>
 												<reference key="NSSuperview" ref="663765878"/>
 												<reference key="NSWindow"/>
 												<reference key="NSNextKeyView" ref="152625445"/>
@@ -721,18 +720,16 @@
 												<reference key="NSBGColor" ref="827363147"/>
 												<int key="NScvFlags">4</int>
 											</object>
-											<reference ref="688592759"/>
 										</array>
 										<string key="NSFrameSize">{955, 147}</string>
 										<reference key="NSSuperview" ref="24227530"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="688592759"/>
+										<reference key="NSNextKeyView" ref="546023969"/>
 										<int key="NSsFlags">133808</int>
 										<reference key="NSVScroller" ref="152625445"/>
 										<reference key="NSHScroller" ref="452331733"/>
 										<reference key="NSContentView" ref="546023969"/>
 										<reference key="NSHeaderClipView" ref="906093892"/>
-										<reference key="NSCornerView" ref="688592759"/>
 										<bytes key="NSScrollAmts">QSAAAEEgAABBmAAAQZgAAA</bytes>
 										<double key="NSMinMagnification">0.25</double>
 										<double key="NSMaxMagnification">4</double>
@@ -967,7 +964,6 @@
 										<string key="NSFrameSize">{955, 233}</string>
 										<reference key="NSSuperview" ref="560436169"/>
 										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="657042048"/>
 										<array class="NSMutableArray" key="NSTabViewItems">
 											<object class="NSTabViewItem" id="375889551">
 												<string key="NSIdentifier">1</string>
@@ -1039,10 +1035,10 @@
 																				<object class="NSOutlineView" id="216928480">
 																					<reference key="NSNextResponder" ref="859661469"/>
 																					<int key="NSvFlags">4368</int>
-																					<string key="NSFrameSize">{216, 233}</string>
+																					<string key="NSFrameSize">{231, 233}</string>
 																					<reference key="NSSuperview" ref="859661469"/>
 																					<reference key="NSWindow"/>
-																					<reference key="NSNextKeyView" ref="692013536"/>
+																					<reference key="NSNextKeyView" ref="471196443"/>
 																					<bool key="NSEnabled">YES</bool>
 																					<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 																					<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -1053,7 +1049,7 @@
 																					</object>
 																					<array class="NSMutableArray" key="NSTableColumns">
 																						<object class="NSTableColumn" id="728334291">
-																							<double key="NSWidth">213</double>
+																							<double key="NSWidth">228</double>
 																							<double key="NSMinWidth">16</double>
 																							<double key="NSMaxWidth">1000</double>
 																							<object class="NSTableHeaderCell" key="NSHeaderCell">
@@ -1097,7 +1093,7 @@
 																					<int key="NSTableViewGroupRowStyle">1</int>
 																				</object>
 																			</array>
-																			<string key="NSFrame">{{1, 1}, {216, 233}}</string>
+																			<string key="NSFrame">{{1, 1}, {231, 233}}</string>
 																			<reference key="NSSuperview" ref="776605770"/>
 																			<reference key="NSWindow"/>
 																			<reference key="NSNextKeyView" ref="216928480"/>
@@ -1108,7 +1104,7 @@
 																		<object class="NSScroller" id="692013536">
 																			<reference key="NSNextResponder" ref="776605770"/>
 																			<int key="NSvFlags">256</int>
-																			<string key="NSFrame">{{217, 1}, {15, 233}}</string>
+																			<string key="NSFrame">{{216, 1}, {16, 233}}</string>
 																			<reference key="NSSuperview" ref="776605770"/>
 																			<reference key="NSWindow"/>
 																			<reference key="NSNextKeyView" ref="891500945"/>
@@ -1135,7 +1131,7 @@
 																	<string key="NSFrameSize">{233, 235}</string>
 																	<reference key="NSSuperview" ref="626906425"/>
 																	<reference key="NSWindow"/>
-																	<reference key="NSNextKeyView" ref="471196443"/>
+																	<reference key="NSNextKeyView" ref="859661469"/>
 																	<int key="NSsFlags">133138</int>
 																	<reference key="NSVScroller" ref="692013536"/>
 																	<reference key="NSHScroller" ref="471196443"/>


### PR DESCRIPTION
I do a lot of reviewing of code hosted in an SVN repo; developers will often reference the SVN revision number of changes. This patch adds another column to the history view that shows the SVN revision number, extracted from the `git-svn-id` line. This allows for quickly mapping between git and SVN commits.

In quick testing, performance doesn't seem to be heavily impacted, but if others find differently it could be an off-by-default option.

(Apologies also for the XIB diff spam, I'm never sure which of the bits IB changes are actually required, so I played it safe and committed the whole thing)
