### PR TITLE
Refuse dragged items as described in #165

### DIFF
--- a/Classes/Controllers/PBWebController.m
+++ b/Classes/Controllers/PBWebController.m
@@ -114,6 +114,12 @@ decisionListener:(id <WebPolicyDecisionListener>)listener
 	}
 }
 
+- (NSUInteger)webView:(WebView *)webView
+dragDestinationActionMaskForDraggingInfo:(id<NSDraggingInfo>)draggingInfo
+{
+    return NSDragOperationNone;
+}
+
 + (BOOL)isSelectorExcludedFromWebScript:(SEL)aSelector
 {
 	return NO;


### PR DESCRIPTION
Very simple change to refuse dragged items in `PBWebController`'s `WebView`. Although #165 only mentions the diff view, it doesn't look like any of those managed by `PBWebController` should be accepting drags so this covers all of them. If that's not correct, it's easy to move the same `-webView:dragDestinationActionMaskForDraggingInfo:` into the individual view classes, of course.
