### PR TITLE
More NSDocument cleanup.

### DIFF
--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -9,7 +9,6 @@
 #import "ApplicationController.h"
 #import "PBGitRevisionCell.h"
 #import "PBGitWindowController.h"
-#import "PBRepositoryDocumentController.h"
 #import "PBServicesController.h"
 #import "PBGitXProtocol.h"
 #import "PBPrefsWindowController.h"
@@ -70,7 +69,7 @@ static OpenRecentController* recentsDialog = nil;
 
 - (BOOL)applicationShouldOpenUntitledFile:(NSApplication *)sender
 {
-	if(!started || [[[PBRepositoryDocumentController sharedDocumentController] documents] count])
+	if(!started || [[[NSDocumentController sharedDocumentController] documents] count])
 		return NO;
 	return YES;
 }

--- a/Classes/Controllers/OpenRecentController.m
+++ b/Classes/Controllers/OpenRecentController.m
@@ -8,7 +8,6 @@
 
 #import "OpenRecentController.h"
 #import "PBGitDefaults.h"
-#import "PBRepositoryDocumentController.h"
 
 @implementation OpenRecentController
 
@@ -77,9 +76,9 @@
 {
 	[self changeSelection:self];
 	if(selectedResult != nil) {
-		[[PBRepositoryDocumentController sharedDocumentController] openDocumentWithContentsOfURL:selectedResult
-																						 display:YES
-																						   error:nil];
+		[[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:selectedResult
+                                                                               display:YES
+                                                                                 error:nil];
 	}
 	[self hide];
 }
@@ -88,9 +87,9 @@
     BOOL result = NO;
     if (commandSelector == @selector(insertNewline:)) {
 		if(selectedResult != nil) {
-			[[PBRepositoryDocumentController sharedDocumentController] openDocumentWithContentsOfURL:selectedResult
-																							 display:YES
-																							   error:nil];
+			[[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:selectedResult
+                                                                                   display:YES
+                                                                                     error:nil];
 		}
 		[self hide];
 //		[searchWindow makeKeyAndOrderFront: nil];

--- a/Classes/Controllers/PBGitSidebarController.m
+++ b/Classes/Controllers/PBGitSidebarController.m
@@ -16,7 +16,6 @@
 #import "PBAddRemoteSheet.h"
 #import "PBGitDefaults.h"
 #import "PBHistorySearchController.h"
-#import "PBRepositoryDocumentController.h"
 
 @interface PBGitSidebarController ()
 
@@ -225,9 +224,9 @@
         PBGitSVSubmoduleItem *subModule = [sourceView itemAtRow:rowNumber];
         
         NSURL *url = [NSURL fileURLWithPath:subModule.submodule.path];
-        [[PBRepositoryDocumentController sharedDocumentController] openDocumentWithContentsOfURL:url
-																						 display:YES
-																						   error:nil];
+        [[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:url
+                                                                               display:YES
+                                                                                 error:nil];
 
         ;
     }

--- a/Classes/Controllers/PBRepositoryDocumentController.h
+++ b/Classes/Controllers/PBRepositoryDocumentController.h
@@ -7,14 +7,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import "PBGitRevSpecifier.h"
-
 
 @interface PBRepositoryDocumentController : NSDocumentController
-{
 
-}
-
-- (id) documentForLocation:(NSURL*) url;
-- (void)initNewRepositoryAtURL:(NSURL *)url;
 @end

--- a/Classes/Controllers/PBServicesController.m
+++ b/Classes/Controllers/PBServicesController.m
@@ -7,7 +7,6 @@
 //
 
 #import "PBServicesController.h"
-#import "PBRepositoryDocumentController.h"
 #import "PBGitRepository.h"
 
 @implementation PBServicesController

--- a/Classes/PBCLIProxy.m
+++ b/Classes/PBCLIProxy.m
@@ -7,7 +7,6 @@
 //
 
 #import "PBCLIProxy.h"
-#import "PBRepositoryDocumentController.h"
 #import "PBGitRevSpecifier.h"
 #import "PBGitRepository.h"
 #import "PBGitWindowController.h"
@@ -38,7 +37,7 @@
 	NSURL* url = [NSURL fileURLWithPath:[repositoryPath path]];
 	NSArray* arguments = [NSArray arrayWithArray:args];
 
-	PBGitRepository *document = [[PBRepositoryDocumentController sharedDocumentController] documentForLocation:url];
+	PBGitRepository *document = [[NSDocumentController sharedDocumentController] documentForURL:url];
 	if (!document) {
 		if (error) {
 			NSString *suggestion = [PBGitBinary path] ? @"this isn't a git repository" : @"GitX can't find your git binary";

--- a/Classes/Views/PBCloneRepositoryPanel.m
+++ b/Classes/Views/PBCloneRepositoryPanel.m
@@ -8,7 +8,6 @@
 
 #import "PBCloneRepositoryPanel.h"
 #import "PBRemoteProgressSheet.h"
-#import "PBRepositoryDocumentController.h"
 #import "PBGitDefaults.h"
 
 
@@ -166,7 +165,7 @@
 	NSURL *documentURL = [NSURL fileURLWithPath:path];
 	
 	NSError *error = nil;
-	id document = [[PBRepositoryDocumentController sharedDocumentController] openDocumentWithContentsOfURL:documentURL display:YES error:&error];
+	id document = [[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:documentURL display:YES error:&error];
 	if (!document && error)
 			[self showErrorSheet:error];
 	else {

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -103,7 +103,6 @@ static NSString * PBStringFromBranchFilterType(PBGitXBranchFilterType type) {
 - (NSString *) projectName;
 - (NSString *)gitIgnoreFilename;
 - (BOOL)isBareRepository;
-+ (BOOL)isBareRepository:(NSURL*)repositoryURL;
 
 - (BOOL)hasSVNRemote;
 

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -15,6 +15,8 @@
 @class GTConfiguration;
 
 extern NSString* PBGitRepositoryErrorDomain;
+extern NSString *PBGitRepositoryDocumentType;
+
 typedef enum branchFilterTypes {
 	kGitXAllBranchesFilter = 0,
 	kGitXLocalRemoteBranchesFilter,
@@ -133,7 +135,6 @@ static NSString * PBStringFromBranchFilterType(PBGitXBranchFilterType type) {
 - (NSString*) parseSymbolicReference:(NSString*) ref;
 - (NSString*) parseReference:(NSString*) ref;
 
-- (id) initWithURL: (NSURL*) path;
 - (void) forceUpdateRevisions;
 - (NSURL*) getIndexURL;
 

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -39,17 +39,9 @@
 @synthesize revisionList, branchesSet, currentBranch, refs, hasChanged, submodules;
 @synthesize currentBranchFilter;
 
-+ (BOOL) isBareRepository: (NSURL*) url
-{
-	NSError* pError;
-	GTRepository* gitRepo = [[GTRepository alloc] initWithURL:url error:&pError];
-
-	return gitRepo && git_repository_is_bare([gitRepo git_repository]);
-}
-
 - (BOOL) isBareRepository
 {
-	return [PBGitRepository isBareRepository:[self fileURL]];
+    return self.gtRepo.isBare;
 }
 
 - (BOOL) readHasSVNRemoteFromConfig

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -172,7 +172,7 @@
 // The fileURL the document keeps is to the working dir
 - (NSString *) displayName
 {
-	if (![[PBGitRef refFromString:[[self headRef] simpleRef]] type])
+    if (self.gtRepo.isHeadDetached)
 		return [NSString stringWithFormat:@"%@ (detached HEAD)", [self projectName]];
 
 	return [NSString stringWithFormat:@"%@ (branch: %@)", [self projectName], [[self headRef] description]];

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -39,16 +39,6 @@
 @synthesize revisionList, branchesSet, currentBranch, refs, hasChanged, submodules;
 @synthesize currentBranchFilter;
 
-- (BOOL)readFromData:(NSData *)data ofType:(NSString *)typeName error:(NSError **)outError
-{
-	if (outError) {
-		*outError = [NSError errorWithDomain:PBGitRepositoryErrorDomain
-                                      code:0
-                                  userInfo:[NSDictionary dictionaryWithObject:@"Reading files is not supported." forKey:NSLocalizedFailureReasonErrorKey]];
-	}
-	return NO;
-}
-
 + (BOOL) isBareRepository: (NSURL*) url
 {
 	NSError* pError;

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -28,6 +28,8 @@
 #import <ObjectiveGit/GTIndex.h>
 #import <ObjectiveGit/GTConfiguration.h>
 
+NSString *PBGitRepositoryDocumentType = @"Git Repository";
+
 @interface PBGitRepository ()
 
 @property (nonatomic, strong) NSNumber *hasSVNRepoConfig;
@@ -134,29 +136,6 @@
 	[revisionList cleanup];
 
 	[super close];
-}
-
-- (id) initWithURL: (NSURL*) path
-{
-	if (![PBGitBinary path])
-		return nil;
-
-    self = [self initWithContentsOfURL:path ofType:@"" error:NULL];
-	if (!self)
-	{
-		NSLog(@"Failed to initWithURL:%@", path);
-		return nil;
-	}
-
-	// We don't want the window controller to display anything yet..
-	// We'll leave that to the caller of this method.
-#ifndef CLI
-	[self addWindowController:[[PBGitWindowController alloc] initWithRepository:self displayDefault:NO]];
-#endif
-
-	[self showWindows];
-
-	return self;
 }
 
 - (void) forceUpdateRevisions


### PR DESCRIPTION
I think I'm done with that now. I moved some methods around, sadly I can't make PBGitRepository completely self-contained because there's no way to create a new document at a specific path, so `New` stuff is handled by creating a repo with `GTRepository` and then opening that. So now `GTRrepository` handles all repository creation ;-).

I tested the Recent Menu a good while — since I removed a good chunk of custom code — but haven't been able to make it behave strangely. If you can get it to do something wrong, by all means yell.

Still untested, moving around the repository folder. I'm wondering how the code'll react to that though ;-).
