### PR TITLE
Use the v3 API for creating gists

### DIFF
--- a/Classes/Controllers/PBWebHistoryController.m
+++ b/Classes/Controllers/PBWebHistoryController.m
@@ -9,6 +9,7 @@
 #import "PBWebHistoryController.h"
 #import "PBGitDefaults.h"
 #import "PBGitSHA.h"
+#import <ObjectiveGit/GTConfiguration.h>
 
 @implementation PBWebHistoryController
 
@@ -164,9 +165,10 @@ contextMenuItemsForElement:(NSDictionary *)element
 	[[NSWorkspace sharedWorkspace] openURL:[request URL]];
 }
 
-- getConfig:(NSString *)config
+- getConfig:(NSString *)key
 {
-	return [historyController valueForKeyPath:[@"repository.config." stringByAppendingString:config]];
+    GTConfiguration* config = historyController.repository.gtRepo.configuration;
+	return [config stringForKey:key];
 }
 
 

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -87,13 +87,8 @@ var gistie = function() {
 	var filename = commit.object.subject.replace(/[^a-zA-Z0-9]/g, "-") + ".patch";
 	parameters.files[filename] = {content: commit.object.patch()};
 
+	var accessToken = Controller.getConfig_("github.token"); // obtain a personal access token from https://github.com/settings/applications
 	// TODO: Replace true with private preference
-	token = Controller.getConfig_("github.token");
-	login = Controller.getConfig_("github.user");
-	if (token && login) {
-		parameters.login = login;
-		parameters.token = token;
-	}
 	if (Controller.isFeatureEnabled_("publicGist"))
 		parameters.public = true;
 
@@ -112,6 +107,8 @@ var gistie = function() {
 	}
 
 	t.open('POST', "https://api.github.com/gists");
+	if (accessToken)
+		t.setRequestHeader('Authorization', 'token '+accessToken);
 	t.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 	t.setRequestHeader('Accept', 'text/javascript, text/html, application/xml, text/xml, */*');
 	t.setRequestHeader('Content-type', 'application/x-www-form-urlencoded;charset=UTF-8');

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -106,10 +106,11 @@ var gistie = function() {
 
 	var t = new XMLHttpRequest();
 	t.onreadystatechange = function() {
-		if (t.readyState == 4 && t.status >= 200 && t.status < 300) {
-			if (m = t.responseText.match(/<a href="\/gists\/([a-f0-9]+)\/edit">/))
+		if (t.readyState == 4) {
+			var m, success = t.status >= 200 && t.status < 300;
+			if (success && (m = t.responseText.match(/<a href="\/gists\/([a-f0-9]+)\/edit">/))) {
 				notify("Code uploaded to gistie <a target='_new' href='http://gist.github.com/" + m[1] + "'>#" + m[1] + "</a>", 1);
-			else {
+			} else {
 				notify("Pasting to Gistie failed :(.", -1);
 				Controller.log_(t.responseText);
 			}


### PR DESCRIPTION
Hi there,
As far as I can tell, the "Gist it" button has been dead for a while.  This series of commits fixes it up to use the latest version of the github API.

The one part I'm not too sure about is using github.token.  If you haven't set this in your config, it'll just post anonymous gists.  If you obtain a personal token from https://github.com/settings/applications and set github.token to it, it'll create gists tied to your account.  However, github.token dates back from ancient times, and I'm not sure if I should be reusing it in this way (or if old github.token's are still valid for OAuth authentication).  Perhaps it should be a new UI field in GitX's preferences rather than a git config value...
