### PR TITLE
Update help link to GitX fork website

### DIFF
--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -203,7 +203,7 @@ static OpenRecentController* recentsDialog = nil;
 
 - (IBAction)showHelp:(id)sender
 {
-	[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"http://gitx.frim.nl/user_manual.html"]];
+	[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"http://rowanj.github.io/gitx/"]];
 }
 
 - (IBAction)reportAProblem:(id)sender


### PR DESCRIPTION
I think the Help menu should link to the fork webpage and the user can then find the original manual if really needed (it's so outdated I think it's more confusing than helpful).
