### PR TITLE
Add details about GitX-dev fork in About menu

### DIFF
--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -119,8 +119,10 @@ static OpenRecentController* recentsDialog = nil;
 		[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:gitversion, @"Version", nil]];
 
 	#ifdef DEBUG_BUILD
-		[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:@"GitX (DEBUG)", @"ApplicationName", nil]];
+		[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:@"GitX-dev (DEBUG)", @"ApplicationName", nil]];
 	#endif
+
+	[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:@"GitX-dev (rowanj fork)", @"ApplicationName", nil]];
 
 	[NSApp orderFrontStandardAboutPanelWithOptions:dict];
 }

--- a/Resources/Credits.html
+++ b/Resources/Credits.html
@@ -1,1 +1,11 @@
-<a href="http://rowanj.github.com/gitx/">GitX Homepage</a>
+<style type="text/css">
+p {
+  font-family: Lucida Grande;
+  font-size: 10px;
+  text-align: center;
+}
+</style>
+<p>By developers, for developers.</p>
+<p style="margin: 0px; padding: 0px">
+  <a href="http://rowanj.github.io/gitx/">http://rowanj.github.io/gitx/</a>
+</p>


### PR DESCRIPTION
- Add fork name & tag line
- Update link to current github.io domain

This is what it looks like :

![gitxfork](https://f.cloud.github.com/assets/143380/726417/5fd66fcc-e0f5-11e2-94e2-943cb23617b8.png)

I think that would help figuring out which fork coworker are using until it is fully re-branded or renamed.
