### PR TITLE
Hyperlink `#123` to the respective issue/ticket

### DIFF
--- a/Classes/Controllers/PBGitHistoryController.h
+++ b/Classes/Controllers/PBGitHistoryController.h
@@ -80,6 +80,8 @@
 - (void)showCommitsFromTree:(id)sender;
 - (void)showInFinderAction:(id)sender;
 - (void)openFilesAction:(id)sender;
+- (void) showConfigureGitxTicketUrl:(id)sender;
+- (NSArray *)menuItemsForTicketLink;
 
 // Repository Methods
 - (IBAction) createBranch:(id)sender;

--- a/Classes/Controllers/PBGitHistoryController.h
+++ b/Classes/Controllers/PBGitHistoryController.h
@@ -81,7 +81,8 @@
 - (void)showInFinderAction:(id)sender;
 - (void)openFilesAction:(id)sender;
 - (void) showConfigureGitxTicketUrl:(id)sender;
-- (NSArray *)menuItemsForTicketLink;
+- (void) showTicketWithNumber:(NSString *)ticketNumber;
+- (NSArray *)menuItemsForTicketLink:(NSString *)ticketNumber;
 
 // Repository Methods
 - (IBAction) createBranch:(id)sender;

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -640,6 +640,23 @@
 	return menuItems;
 }
 
+- (void) showConfigureGitxTicketUrl:(id)sender
+{
+    NSString *message = @"Configure Ticket/Issue URL:";
+    NSString *info = @"It can be configured via gitx.ticketurl git-config setting.\n\n"
+                      "$ git config gitx.ticketurl 'http://example.org/issues/{id}'\n\n";
+    [self.repository.windowController showMessageSheet:message infoText:info];
+}
+
+- (NSArray *)menuItemsForTicketLink
+{
+    NSMenuItem *configureGitxTicketUrl = [[NSMenuItem alloc] initWithTitle:@"Configure URL..."
+														action:@selector(showConfigureGitxTicketUrl:)
+												 keyEquivalent:@""];
+
+    NSArray *menuItems = [NSArray arrayWithObjects:configureGitxTicketUrl, nil];
+    return menuItems;
+}
 
 #pragma mark NSSplitView delegate methods
 

--- a/Classes/Controllers/PBWebHistoryController.m
+++ b/Classes/Controllers/PBWebHistoryController.m
@@ -150,7 +150,8 @@ contextMenuItemsForElement:(NSDictionary *)element
         }
         
         if ([[node className] hasPrefix:@"ticket"]) {
-            return [historyController menuItemsForTicketLink];
+            NSString *ticketNumber = [[[[node childNodes] item:0] textContent] substringFromIndex:1];
+            return [historyController menuItemsForTicketLink:ticketNumber];
         }
         
 		node = [node parentNode];
@@ -167,8 +168,9 @@ contextMenuItemsForElement:(NSDictionary *)element
  decisionListener:(id < WebPolicyDecisionListener >)listener
 {
     if ([[[request URL] scheme] isEqualToString:@"file"]) {
-        if ([[[request URL] fragment] isEqualToString:@"configure-ticketurl"]) {
-            [historyController showConfigureGitxTicketUrl:nil];
+        if ([[[request URL] fragment] hasPrefix:@"ticket:"]) {
+            NSString * ticketNumber = [[[request URL] fragment] substringFromIndex:7];
+            [historyController showTicketWithNumber:ticketNumber];
         }
     }
     else {

--- a/Classes/Controllers/PBWebHistoryController.m
+++ b/Classes/Controllers/PBWebHistoryController.m
@@ -148,7 +148,11 @@ contextMenuItemsForElement:(NSDictionary *)element
 					return [NSArray arrayWithObject:item];
 			return nil;
         }
-
+        
+        if ([[node className] hasPrefix:@"ticket"]) {
+            return [historyController menuItemsForTicketLink];
+        }
+        
 		node = [node parentNode];
 	}
 
@@ -162,7 +166,14 @@ contextMenuItemsForElement:(NSDictionary *)element
      newFrameName:(NSString *)frameName
  decisionListener:(id < WebPolicyDecisionListener >)listener
 {
-	[[NSWorkspace sharedWorkspace] openURL:[request URL]];
+    if ([[[request URL] scheme] isEqualToString:@"file"]) {
+        if ([[[request URL] fragment] isEqualToString:@"configure-ticketurl"]) {
+            [historyController showConfigureGitxTicketUrl:nil];
+        }
+    }
+    else {
+        [[NSWorkspace sharedWorkspace] openURL:[request URL]];
+    }
 }
 
 - getConfig:(NSString *)key

--- a/Classes/Views/PBGitXConfigureTicketURLSheet.h
+++ b/Classes/Views/PBGitXConfigureTicketURLSheet.h
@@ -1,0 +1,30 @@
+//
+//  PBGitXConfigureTicketURLSheet.h
+//  GitX
+//
+//  Created by Mathias Leppich on 7/11/13.
+//  Copyright 2013 Mathias Leppich. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+#import "RJModalRepoSheet.h"
+
+#define GITX_TICKET_URL_SETTING @"gitx.ticketurl"
+
+@interface PBGitXConfigureTicketURLSheet : RJModalRepoSheet
+{
+	NSImageView *iconView;
+    NSTextField *ticketURLTextField;
+}
+
++ (void)beginConfigureTicketURLSheetForRepo:(PBGitRepository *)repo;
+
+- (void)beginConfigureTicketURLSheet;
+
+- (IBAction)closeMessageSheet:(id)sender;
+
+@property  IBOutlet NSImageView *iconView;
+@property  IBOutlet NSTextField *ticketURLTextField;
+
+@end

--- a/Classes/Views/PBGitXConfigureTicketURLSheet.m
+++ b/Classes/Views/PBGitXConfigureTicketURLSheet.m
@@ -1,0 +1,98 @@
+//
+//  PBGitXConfigureTicketURLSheet.m
+//  GitX
+//
+//  Created by Mathias Leppich on 7/11/13.
+//  Copyright 2013 Mathias Leppich. All rights reserved.
+//
+
+#import "PBGitXConfigureTicketURLSheet.h"
+
+#import "PBGitRepository.h"
+#import <ObjectiveGit/GTRepository.h>
+#import <ObjectiveGit/GTConfiguration.h>
+
+@interface PBGitXConfigureTicketURLSheet ()
+
+@end
+
+@implementation PBGitXConfigureTicketURLSheet
+
+@synthesize iconView, ticketURLTextField;
+
+
+#pragma mark -
+#pragma mark PBGitXConfigureTicketURLSheet 
+
++ (void)beginConfigureTicketURLSheetForRepo:(PBGitRepository *)repo
+{
+    PBGitXConfigureTicketURLSheet *sheet = [[self alloc] initWithWindowNibName:@"PBGitXConfigureTicketURLSheet"
+                                                                       forRepo:repo];
+    [sheet beginConfigureTicketURLSheet];
+}
+
+- (id)initWithWindowNibName:(NSString *)windowNibName
+					forRepo:(PBGitRepository *)repo
+{
+	self = [super initWithWindowNibName:windowNibName forRepo:repo];
+	if (!self)
+		return nil;
+	return self;
+}
+
+- (IBAction)closeMessageSheet:(id)sender
+{
+	[self hide];
+}
+
+#pragma mark Private
+- (void)beginConfigureTicketURLSheet {
+    [self window];
+    
+    [self loadSettings];
+    
+    [self show];
+}
+
+- (void)loadSettings {
+    NSError *error = nil;
+    GTConfiguration* config = [self.repository.gtRepo configurationWithError:&error];
+	NSString * currentTicketURL = [config stringForKey:GITX_TICKET_URL_SETTING];
+    if (currentTicketURL == nil) {
+        currentTicketURL = @"";
+    }
+    ticketURLTextField.stringValue = currentTicketURL;
+    NSLog(@"loadSettings: %@", currentTicketURL);
+}
+
+- (void)persistSettings {
+   	NSString * currentTicketURL = [ticketURLTextField stringValue];
+    NSLog(@"persistSettings: %@", currentTicketURL);
+    NSError *error = nil;
+    GTConfiguration* config = [self.repository.gtRepo configurationWithError:&error];
+    if ([currentTicketURL isEqualToString:@""]) {
+        [config deleteValueForKey:GITX_TICKET_URL_SETTING error:&error];
+    } else {
+        [config setString:currentTicketURL forKey:GITX_TICKET_URL_SETTING];
+    }
+}
+
+- (void)show {
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(controlTextDidChange:)
+                                                 name: NSControlTextDidChangeNotification
+                                               object: ticketURLTextField];
+    [super show];
+}
+
+- (void)hide {
+    [[NSNotificationCenter defaultCenter] removeObserver: self];
+    [super hide];
+}
+
+- (void)controlTextDidChange:(NSNotification *)obj {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self];
+    [self performSelector:@selector(persistSettings) withObject:self afterDelay:0.2];
+}
+
+@end

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -181,6 +181,8 @@
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		911112370E5A097800BF76B4 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 911112360E5A097800BF76B4 /* Security.framework */; };
 		913D5E500E55645900CECEA2 /* gitx in Resources */ = {isa = PBXBuildFile; fileRef = 913D5E490E55644600CECEA2 /* gitx */; };
+		A2EA3604178ECB5300636291 /* PBGitXConfigureTicketURLSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = A2EA3603178ECB5300636291 /* PBGitXConfigureTicketURLSheet.xib */; };
+		A2EA3610178ED22A00636291 /* PBGitXConfigureTicketURLSheet.m in Sources */ = {isa = PBXBuildFile; fileRef = A2EA360F178ED22A00636291 /* PBGitXConfigureTicketURLSheet.m */; };
 		BC0444AD17648CC900353E6D /* AddRemoteTemplate.png in Resources */ = {isa = PBXBuildFile; fileRef = BC0444AC17648CC900353E6D /* AddRemoteTemplate.png */; };
 		BC0444B817648D0200353E6D /* BranchHighlighted.png in Resources */ = {isa = PBXBuildFile; fileRef = BC0444B717648D0200353E6D /* BranchHighlighted.png */; };
 		BC0444BA17648DA800353E6D /* FolderHighlighted.png in Resources */ = {isa = PBXBuildFile; fileRef = BC0444B917648DA700353E6D /* FolderHighlighted.png */; };
@@ -644,6 +646,9 @@
 		8D1107320486CEB800E47090 /* GitX.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitX.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		911112360E5A097800BF76B4 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = /System/Library/Frameworks/Security.framework; sourceTree = "<absolute>"; };
 		913D5E490E55644600CECEA2 /* gitx */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = gitx; sourceTree = BUILT_PRODUCTS_DIR; };
+		A2EA3603178ECB5300636291 /* PBGitXConfigureTicketURLSheet.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PBGitXConfigureTicketURLSheet.xib; sourceTree = "<group>"; };
+		A2EA360E178ED22A00636291 /* PBGitXConfigureTicketURLSheet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGitXConfigureTicketURLSheet.h; sourceTree = "<group>"; };
+		A2EA360F178ED22A00636291 /* PBGitXConfigureTicketURLSheet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGitXConfigureTicketURLSheet.m; sourceTree = "<group>"; };
 		BC0444AC17648CC900353E6D /* AddRemoteTemplate.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AddRemoteTemplate.png; sourceTree = "<group>"; };
 		BC0444B717648D0200353E6D /* BranchHighlighted.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = BranchHighlighted.png; sourceTree = "<group>"; };
 		BC0444B917648DA700353E6D /* FolderHighlighted.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = FolderHighlighted.png; sourceTree = "<group>"; };
@@ -935,6 +940,7 @@
 				4A5D75BE14A9A90500DF6C68 /* PBGitHistoryView.xib */,
 				4A5D75BF14A9A90500DF6C68 /* PBGitSidebarView.xib */,
 				4A5D75C014A9A90500DF6C68 /* PBGitXMessageSheet.xib */,
+				A2EA3603178ECB5300636291 /* PBGitXConfigureTicketURLSheet.xib */,
 			);
 			path = XIBs;
 			sourceTree = "<group>";
@@ -1176,6 +1182,8 @@
 				4A5D777014A9AEB000DF6C68 /* PBSourceViewItems.h */,
 				4A5D777114A9AEB000DF6C68 /* PBSourceViewRemote.h */,
 				4A5D777214A9AEB000DF6C68 /* PBSourceViewRemote.m */,
+				A2EA360E178ED22A00636291 /* PBGitXConfigureTicketURLSheet.h */,
+				A2EA360F178ED22A00636291 /* PBGitXConfigureTicketURLSheet.m */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1499,6 +1507,7 @@
 				BC0444C617648EBE00353E6D /* TagHighlighted.png in Resources */,
 				BC77578C176766B60048BB48 /* BranchTemplate@2x.png in Resources */,
 				BC775797176766C60048BB48 /* RemoteBranchTemplate@2x.png in Resources */,
+				A2EA3604178ECB5300636291 /* PBGitXConfigureTicketURLSheet.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1642,6 +1651,7 @@
 				643952741603E9BC00BB7AFF /* PBGitSubmodule.m in Sources */,
 				643952771603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m in Sources */,
 				4AB057E31652652000DE751D /* GitRepoFinder.m in Sources */,
+				A2EA3610178ED22A00636291 /* PBGitXConfigureTicketURLSheet.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resources/XIBs/PBGitXConfigureTicketURLSheet.xib
+++ b/Resources/XIBs/PBGitXConfigureTicketURLSheet.xib
@@ -1,0 +1,967 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
+	<data>
+		<int key="IBDocument.SystemTarget">1080</int>
+		<string key="IBDocument.SystemVersion">12E55</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.39</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
+			<string key="NS.object.0">3084</string>
+		</object>
+		<array key="IBDocument.IntegratedClassDependencies">
+			<string>IBNSLayoutConstraint</string>
+			<string>NSButton</string>
+			<string>NSButtonCell</string>
+			<string>NSCustomObject</string>
+			<string>NSImageCell</string>
+			<string>NSImageView</string>
+			<string>NSTextField</string>
+			<string>NSTextFieldCell</string>
+			<string>NSView</string>
+			<string>NSWindowTemplate</string>
+		</array>
+		<array key="IBDocument.PluginDependencies">
+			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+		</array>
+		<object class="NSMutableDictionary" key="IBDocument.Metadata">
+			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
+			<integer value="1" key="NS.object.0"/>
+		</object>
+		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
+			<object class="NSCustomObject" id="1001">
+				<string key="NSClassName">PBGitXConfigureTicketURLSheet</string>
+			</object>
+			<object class="NSCustomObject" id="1003">
+				<string key="NSClassName">FirstResponder</string>
+			</object>
+			<object class="NSCustomObject" id="1004">
+				<string key="NSClassName">NSApplication</string>
+			</object>
+			<object class="NSWindowTemplate" id="382248082">
+				<int key="NSWindowStyleMask">1</int>
+				<int key="NSWindowBacking">2</int>
+				<string key="NSWindowRect">{{196, 331}, {540, 179}}</string>
+				<int key="NSWTFlags">544736256</int>
+				<string key="NSWindowTitle">Window</string>
+				<string key="NSWindowClass">NSWindow</string>
+				<nil key="NSViewClass"/>
+				<nil key="NSUserInterfaceItemIdentifier"/>
+				<object class="NSView" key="NSWindowView" id="741448943">
+					<reference key="NSNextResponder"/>
+					<int key="NSvFlags">256</int>
+					<array class="NSMutableArray" key="NSSubviews">
+						<object class="NSButton" id="586958685">
+							<reference key="NSNextResponder" ref="741448943"/>
+							<int key="NSvFlags">289</int>
+							<string key="NSFrame">{{430, 18}, {96, 32}}</string>
+							<reference key="NSSuperview" ref="741448943"/>
+							<reference key="NSWindow"/>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSButtonCell" key="NSCell" id="776960146">
+								<int key="NSCellFlags">67108864</int>
+								<int key="NSCellFlags2">134217728</int>
+								<string key="NSContents">OK</string>
+								<object class="NSFont" key="NSSupport" id="532934402">
+									<string key="NSName">LucidaGrande</string>
+									<double key="NSSize">13</double>
+									<int key="NSfFlags">1044</int>
+								</object>
+								<reference key="NSControlView" ref="586958685"/>
+								<int key="NSButtonFlags">-2038284288</int>
+								<int key="NSButtonFlags2">129</int>
+								<string key="NSAlternateContents"/>
+								<string type="base64-UTF8" key="NSKeyEquivalent">DQ</string>
+								<int key="NSPeriodicDelay">200</int>
+								<int key="NSPeriodicInterval">25</int>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
+						<object class="NSImageView" id="517117310">
+							<reference key="NSNextResponder" ref="741448943"/>
+							<int key="NSvFlags">268</int>
+							<set class="NSMutableSet" key="NSDragTypes">
+								<string>Apple PDF pasteboard type</string>
+								<string>Apple PICT pasteboard type</string>
+								<string>Apple PNG pasteboard type</string>
+								<string>NSFilenamesPboardType</string>
+								<string>NeXT Encapsulated PostScript v1.2 pasteboard type</string>
+								<string>NeXT TIFF v4.0 pasteboard type</string>
+							</set>
+							<string key="NSFrame">{{20, 31}, {64, 128}}</string>
+							<reference key="NSSuperview" ref="741448943"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="337862011"/>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSImageCell" key="NSCell" id="308797644">
+								<int key="NSCellFlags">134217728</int>
+								<int key="NSCellFlags2">33554432</int>
+								<object class="NSCustomResource" key="NSContents">
+									<string key="NSClassName">NSImage</string>
+									<string key="NSResourceName">NSApplicationIcon</string>
+								</object>
+								<int key="NSAlign">1</int>
+								<int key="NSScale">0</int>
+								<int key="NSStyle">0</int>
+								<bool key="NSAnimates">NO</bool>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<bool key="NSEditable">YES</bool>
+						</object>
+						<object class="NSTextField" id="337862011">
+							<reference key="NSNextResponder" ref="741448943"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{103, 142}, {420, 17}}</string>
+							<reference key="NSSuperview" ref="741448943"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="761735413"/>
+							<string key="NSReuseIdentifierKey">_NS:1535</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="742316712">
+								<int key="NSCellFlags">68157504</int>
+								<int key="NSCellFlags2">272630784</int>
+								<string key="NSContents">Configure Ticket/Issue URL</string>
+								<object class="NSFont" key="NSSupport">
+									<string key="NSName">LucidaGrande-Bold</string>
+									<double key="NSSize">13</double>
+									<int key="NSfFlags">2072</int>
+								</object>
+								<string key="NSCellIdentifier">_NS:1535</string>
+								<reference key="NSControlView" ref="337862011"/>
+								<object class="NSColor" key="NSBackgroundColor" id="652301539">
+									<int key="NSColorSpace">6</int>
+									<string key="NSCatalogName">System</string>
+									<string key="NSColorName">controlColor</string>
+									<object class="NSColor" key="NSColor">
+										<int key="NSColorSpace">3</int>
+										<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
+									</object>
+								</object>
+								<object class="NSColor" key="NSTextColor" id="864969802">
+									<int key="NSColorSpace">6</int>
+									<string key="NSCatalogName">System</string>
+									<string key="NSColorName">controlTextColor</string>
+									<object class="NSColor" key="NSColor" id="176702145">
+										<int key="NSColorSpace">3</int>
+										<bytes key="NSWhite">MAA</bytes>
+									</object>
+								</object>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
+						<object class="NSTextField" id="761735413">
+							<reference key="NSNextResponder" ref="741448943"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{103, 94}, {420, 40}}</string>
+							<reference key="NSSuperview" ref="741448943"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="586958685"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<string key="NSAntiCompressionPriority">{250, 750}</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="28444248">
+								<int key="NSCellFlags">67108864</int>
+								<int key="NSCellFlags2">272629760</int>
+								<string type="base64-UTF8" key="NSContents">SXQgY2FuIGJlIGNvbmZpZ3VyZWQgdmlhIGdpdHgudGlja2V0dXJsIGdpdC1jb25maWcgc2V0dGluZy4K
+Tm90ZSB0aGF0ICJ7aWR9IiB3aWxsIGJlIHJlcGxhY2VkIGJ5IHRoZSBudW1iZXIgb2YgIzEyMy4KA</string>
+								<object class="NSFont" key="NSSupport">
+									<string key="NSName">LucidaGrande</string>
+									<double key="NSSize">13</double>
+									<int key="NSfFlags">16</int>
+								</object>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<reference key="NSControlView" ref="761735413"/>
+								<reference key="NSBackgroundColor" ref="652301539"/>
+								<reference key="NSTextColor" ref="864969802"/>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<bool key="NSControlAutosetMaxLayoutWidth">YES</bool>
+						</object>
+						<object class="NSTextField" id="337535202">
+							<reference key="NSNextResponder" ref="741448943"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{103, 63}, {127, 17}}</string>
+							<reference key="NSSuperview" ref="741448943"/>
+							<reference key="NSWindow"/>
+							<string key="NSReuseIdentifierKey">_NS:1535</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="268985225">
+								<int key="NSCellFlags">68157504</int>
+								<int key="NSCellFlags2">272630784</int>
+								<string key="NSContents">gitx.ticketurl = </string>
+								<object class="NSFont" key="NSSupport">
+									<string key="NSName">Menlo-Regular</string>
+									<double key="NSSize">12</double>
+									<int key="NSfFlags">16</int>
+								</object>
+								<string key="NSCellIdentifier">_NS:1535</string>
+								<reference key="NSControlView" ref="337535202"/>
+								<reference key="NSBackgroundColor" ref="652301539"/>
+								<reference key="NSTextColor" ref="864969802"/>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
+						<object class="NSTextField" id="763910386">
+							<reference key="NSNextResponder" ref="741448943"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{225, 58}, {295, 22}}</string>
+							<reference key="NSSuperview" ref="741448943"/>
+							<reference key="NSWindow"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="1069921596">
+								<int key="NSCellFlags">-1804599231</int>
+								<int key="NSCellFlags2">272630784</int>
+								<string key="NSContents"/>
+								<reference key="NSSupport" ref="532934402"/>
+								<string key="NSPlaceholderString">e.g. http://example.org/issue/{id}</string>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<reference key="NSControlView" ref="763910386"/>
+								<bool key="NSDrawsBackground">YES</bool>
+								<object class="NSColor" key="NSBackgroundColor">
+									<int key="NSColorSpace">6</int>
+									<string key="NSCatalogName">System</string>
+									<string key="NSColorName">textBackgroundColor</string>
+									<object class="NSColor" key="NSColor">
+										<int key="NSColorSpace">3</int>
+										<bytes key="NSWhite">MQA</bytes>
+									</object>
+								</object>
+								<object class="NSColor" key="NSTextColor">
+									<int key="NSColorSpace">6</int>
+									<string key="NSCatalogName">System</string>
+									<string key="NSColorName">textColor</string>
+									<reference key="NSColor" ref="176702145"/>
+								</object>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
+					</array>
+					<string key="NSFrameSize">{540, 179}</string>
+					<reference key="NSSuperview"/>
+					<reference key="NSWindow"/>
+					<reference key="NSNextKeyView" ref="517117310"/>
+				</object>
+				<string key="NSScreenRect">{{0, 0}, {2560, 1578}}</string>
+				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
+				<bool key="NSWindowIsRestorable">YES</bool>
+			</object>
+		</array>
+		<object class="IBObjectContainer" key="IBDocument.Objects">
+			<array class="NSMutableArray" key="connectionRecords">
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">iconView</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="517117310"/>
+					</object>
+					<int key="connectionID">171</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">closeMessageSheet:</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="586958685"/>
+					</object>
+					<int key="connectionID">172</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">window</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="382248082"/>
+					</object>
+					<int key="connectionID">174</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">ticketURLTextField</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="763910386"/>
+					</object>
+					<int key="connectionID">196</int>
+				</object>
+			</array>
+			<object class="IBMutableOrderedSet" key="objectRecords">
+				<array key="orderedObjects">
+					<object class="IBObjectRecord">
+						<int key="objectID">0</int>
+						<array key="object" id="0"/>
+						<reference key="children" ref="1000"/>
+						<nil key="parent"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-2</int>
+						<reference key="object" ref="1001"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">File's Owner</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-1</int>
+						<reference key="object" ref="1003"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">First Responder</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-3</int>
+						<reference key="object" ref="1004"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">Application</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">67</int>
+						<reference key="object" ref="382248082"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="741448943"/>
+						</array>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">68</int>
+						<reference key="object" ref="741448943"/>
+						<array class="NSMutableArray" key="children">
+							<object class="IBNSLayoutConstraint" id="216283535">
+								<reference key="firstItem" ref="741448943"/>
+								<int key="firstAttribute">4</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="586958685"/>
+								<int key="secondAttribute">4</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">25</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="434050082">
+								<reference key="firstItem" ref="741448943"/>
+								<int key="firstAttribute">6</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="586958685"/>
+								<int key="secondAttribute">6</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="648481310">
+								<reference key="firstItem" ref="741448943"/>
+								<int key="firstAttribute">6</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="763910386"/>
+								<int key="secondAttribute">6</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="978017948">
+								<reference key="firstItem" ref="741448943"/>
+								<int key="firstAttribute">4</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="763910386"/>
+								<int key="secondAttribute">4</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">58</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="90660715">
+								<reference key="firstItem" ref="763910386"/>
+								<int key="firstAttribute">3</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="337535202"/>
+								<int key="secondAttribute">3</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">6</int>
+								<float key="scoringTypeFloat">24</float>
+								<int key="contentType">2</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="482965908">
+								<reference key="firstItem" ref="761735413"/>
+								<int key="firstAttribute">5</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="337535202"/>
+								<int key="secondAttribute">5</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">6</int>
+								<float key="scoringTypeFloat">24</float>
+								<int key="contentType">2</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="243494194">
+								<reference key="firstItem" ref="741448943"/>
+								<int key="firstAttribute">6</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="761735413"/>
+								<int key="secondAttribute">6</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="13227021">
+								<reference key="firstItem" ref="761735413"/>
+								<int key="firstAttribute">3</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="337862011"/>
+								<int key="secondAttribute">4</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">8</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">6</int>
+								<float key="scoringTypeFloat">24</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="357616306">
+								<reference key="firstItem" ref="761735413"/>
+								<int key="firstAttribute">5</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="337862011"/>
+								<int key="secondAttribute">5</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">6</int>
+								<float key="scoringTypeFloat">24</float>
+								<int key="contentType">2</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="85092585">
+								<reference key="firstItem" ref="741448943"/>
+								<int key="firstAttribute">6</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="337862011"/>
+								<int key="secondAttribute">6</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="505097061">
+								<reference key="firstItem" ref="337862011"/>
+								<int key="firstAttribute">3</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="741448943"/>
+								<int key="secondAttribute">3</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="426257479">
+								<reference key="firstItem" ref="517117310"/>
+								<int key="firstAttribute">3</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="741448943"/>
+								<int key="secondAttribute">3</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="1036476732">
+								<reference key="firstItem" ref="517117310"/>
+								<int key="firstAttribute">5</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="741448943"/>
+								<int key="secondAttribute">5</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="741448943"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<reference ref="337862011"/>
+							<reference ref="761735413"/>
+							<reference ref="517117310"/>
+							<reference ref="586958685"/>
+							<reference ref="337535202"/>
+							<reference ref="763910386"/>
+						</array>
+						<reference key="parent" ref="382248082"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">69</int>
+						<reference key="object" ref="586958685"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="776960146"/>
+							<object class="IBNSLayoutConstraint" id="346372293">
+								<reference key="firstItem" ref="586958685"/>
+								<int key="firstAttribute">7</int>
+								<int key="relation">0</int>
+								<nil key="secondItem"/>
+								<int key="secondAttribute">0</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">84</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="586958685"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">1</int>
+							</object>
+						</array>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">72</int>
+						<reference key="object" ref="517117310"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="308797644"/>
+							<object class="IBNSLayoutConstraint" id="368762597">
+								<reference key="firstItem" ref="517117310"/>
+								<int key="firstAttribute">7</int>
+								<int key="relation">0</int>
+								<nil key="secondItem"/>
+								<int key="secondAttribute">0</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">64</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="517117310"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">1</int>
+							</object>
+						</array>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">73</int>
+						<reference key="object" ref="308797644"/>
+						<reference key="parent" ref="517117310"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">78</int>
+						<reference key="object" ref="776960146"/>
+						<reference key="parent" ref="586958685"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">80</int>
+						<reference key="object" ref="368762597"/>
+						<reference key="parent" ref="517117310"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">92</int>
+						<reference key="object" ref="346372293"/>
+						<reference key="parent" ref="586958685"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">93</int>
+						<reference key="object" ref="337862011"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="742316712"/>
+							<object class="IBNSLayoutConstraint" id="299747661">
+								<reference key="firstItem" ref="337862011"/>
+								<int key="firstAttribute">7</int>
+								<int key="relation">0</int>
+								<nil key="secondItem"/>
+								<int key="secondAttribute">0</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">414</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="337862011"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">1</int>
+							</object>
+						</array>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">94</int>
+						<reference key="object" ref="742316712"/>
+						<reference key="parent" ref="337862011"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">96</int>
+						<reference key="object" ref="505097061"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">98</int>
+						<reference key="object" ref="761735413"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="28444248"/>
+							<object class="IBNSLayoutConstraint" id="826540529">
+								<reference key="firstItem" ref="761735413"/>
+								<int key="firstAttribute">8</int>
+								<int key="relation">0</int>
+								<nil key="secondItem"/>
+								<int key="secondAttribute">0</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">40</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="761735413"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">1</int>
+							</object>
+						</array>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">99</int>
+						<reference key="object" ref="28444248"/>
+						<reference key="parent" ref="761735413"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">100</int>
+						<reference key="object" ref="357616306"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">101</int>
+						<reference key="object" ref="13227021"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">106</int>
+						<reference key="object" ref="337535202"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="268985225"/>
+							<object class="IBNSLayoutConstraint" id="542638700">
+								<reference key="firstItem" ref="337535202"/>
+								<int key="firstAttribute">8</int>
+								<int key="relation">0</int>
+								<nil key="secondItem"/>
+								<int key="secondAttribute">0</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">17</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="337535202"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">1</int>
+							</object>
+						</array>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">107</int>
+						<reference key="object" ref="268985225"/>
+						<reference key="parent" ref="337535202"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">138</int>
+						<reference key="object" ref="1036476732"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">139</int>
+						<reference key="object" ref="426257479"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">148</int>
+						<reference key="object" ref="434050082"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">151</int>
+						<reference key="object" ref="243494194"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">153</int>
+						<reference key="object" ref="299747661"/>
+						<reference key="parent" ref="337862011"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">154</int>
+						<reference key="object" ref="85092585"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">156</int>
+						<reference key="object" ref="542638700"/>
+						<reference key="parent" ref="337535202"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">162</int>
+						<reference key="object" ref="482965908"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">170</int>
+						<reference key="object" ref="826540529"/>
+						<reference key="parent" ref="761735413"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">187</int>
+						<reference key="object" ref="216283535"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">189</int>
+						<reference key="object" ref="763910386"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="1069921596"/>
+							<object class="IBNSLayoutConstraint" id="955629517">
+								<reference key="firstItem" ref="763910386"/>
+								<int key="firstAttribute">7</int>
+								<int key="relation">0</int>
+								<nil key="secondItem"/>
+								<int key="secondAttribute">0</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">295</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="763910386"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">1</int>
+							</object>
+						</array>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">190</int>
+						<reference key="object" ref="1069921596"/>
+						<reference key="parent" ref="763910386"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">191</int>
+						<reference key="object" ref="90660715"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">192</int>
+						<reference key="object" ref="978017948"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">193</int>
+						<reference key="object" ref="648481310"/>
+						<reference key="parent" ref="741448943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">195</int>
+						<reference key="object" ref="955629517"/>
+						<reference key="parent" ref="763910386"/>
+					</object>
+				</array>
+			</object>
+			<dictionary class="NSMutableDictionary" key="flattenedProperties">
+				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="100.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="101.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<array class="NSMutableArray" key="106.IBNSViewMetadataConstraints">
+					<reference ref="542638700"/>
+				</array>
+				<boolean value="NO" key="106.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
+				<string key="106.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="107.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="138.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="139.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="148.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="151.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="153.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="154.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="156.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="162.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="170.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="187.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<array class="NSMutableArray" key="189.IBNSViewMetadataConstraints">
+					<reference ref="955629517"/>
+				</array>
+				<boolean value="NO" key="189.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
+				<string key="189.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="190.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="191.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="192.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="193.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="195.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="67.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="67.IBWindowTemplateEditedContentRect">{{663, 521}, {540, 179}}</string>
+				<boolean value="NO" key="67.NSWindowTemplate.visibleAtLaunch"/>
+				<array class="NSMutableArray" key="68.IBNSViewMetadataConstraints">
+					<reference ref="1036476732"/>
+					<reference ref="426257479"/>
+					<reference ref="505097061"/>
+					<reference ref="85092585"/>
+					<reference ref="357616306"/>
+					<reference ref="13227021"/>
+					<reference ref="243494194"/>
+					<reference ref="482965908"/>
+					<reference ref="90660715"/>
+					<reference ref="978017948"/>
+					<reference ref="648481310"/>
+					<reference ref="434050082"/>
+					<reference ref="216283535"/>
+				</array>
+				<string key="68.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<array class="NSMutableArray" key="68.IBUserGuides">
+					<object class="IBUserGuide">
+						<reference key="view" ref="741448943"/>
+						<double key="location">103</double>
+						<int key="affinity">0</int>
+					</object>
+				</array>
+				<array key="69.IBNSViewMetadataConstraints">
+					<reference ref="346372293"/>
+				</array>
+				<boolean value="NO" key="69.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
+				<string key="69.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<array class="NSMutableArray" key="72.IBNSViewMetadataConstraints">
+					<reference ref="368762597"/>
+				</array>
+				<boolean value="NO" key="72.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
+				<string key="72.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="73.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="78.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="80.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="92.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<array class="NSMutableArray" key="93.IBNSViewMetadataConstraints">
+					<reference ref="299747661"/>
+				</array>
+				<boolean value="NO" key="93.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
+				<string key="93.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="94.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="96.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<array key="98.IBNSViewMetadataConstraints">
+					<reference ref="826540529"/>
+				</array>
+				<boolean value="NO" key="98.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
+				<string key="98.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="99.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+			</dictionary>
+			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
+			<nil key="activeLocalization"/>
+			<dictionary class="NSMutableDictionary" key="localizations"/>
+			<nil key="sourceID"/>
+			<int key="maxID">196</int>
+		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<object class="IBPartialClassDescription">
+					<string key="className">NSLayoutConstraint</string>
+					<string key="superclassName">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/NSLayoutConstraint.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">PBGitXConfigureTicketURLSheet</string>
+					<string key="superclassName">RJModalRepoSheet</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">closeMessageSheet:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">closeMessageSheet:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">closeMessageSheet:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<dictionary class="NSMutableDictionary" key="outlets">
+						<string key="iconView">NSImageView</string>
+						<string key="ticketURLTextField">NSTextField</string>
+					</dictionary>
+					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<object class="IBToOneOutletInfo" key="iconView">
+							<string key="name">iconView</string>
+							<string key="candidateClassName">NSImageView</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="ticketURLTextField">
+							<string key="name">ticketURLTextField</string>
+							<string key="candidateClassName">NSTextField</string>
+						</object>
+					</dictionary>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/PBGitXConfigureTicketURLSheet.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">RJModalRepoSheet</string>
+					<string key="superclassName">NSWindowController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/RJModalRepoSheet.h</string>
+					</object>
+				</object>
+			</array>
+		</object>
+		<int key="IBDocument.localizationMode">0</int>
+		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
+		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
+		<int key="IBDocument.defaultPropertyAccessControl">3</int>
+		<object class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
+			<string key="NS.key.0">NSApplicationIcon</string>
+			<string key="NS.object.0">{128, 128}</string>
+		</object>
+		<bool key="IBDocument.UseAutolayout">YES</bool>
+	</data>
+</archive>

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -288,33 +288,11 @@ var enableFeatures = function()
 	enableFeature("gravatar", $("committer_gravatar").parentNode)
 }
 
-/*
-Just add gitx.ticketurl to your repositories .git/config
- 
-[gitx]
- ticketurl = "http://trac.domain.com/ticket/{id}"
 
-*/
 var formatTicketUrls = function (html) {
-    var ticketUrl = Controller.getConfig_("gitx.ticketurl");
-    if (!ticketUrl) {
-        var origin = Controller.getConfig_("remote.origin.url");
-        var matches = origin && origin.match(/github.com\/([^\/]+\/[^\/]+)\.git$/);
-        if (matches) {
-            ticketUrl = "https://github.com/"+matches[1]+"/issues/";
-        }
-    }
-    var applyTicketUrl = (!ticketUrl) ? function (id) {
-        return '#configure-ticketurl';
-    } : (ticketUrl.indexOf("{id}") >= 0 ? function (id) {
-        return ticketUrl.replace(/\{id\}/g,id);
-    } : function (id) {
-        return ticketUrl+""+id;
+    return html.replace(/#([0-9]+)/g, function(match,id) {
+        return '<a class="ticket" href="#ticket:'+id+'" target="blank">'+match+'</a>';
     });
-    var replaceTicketLinks = function(match,id) {
-        return '<a class="ticket" href="'+applyTicketUrl(id)+'" target="blank">'+match+'</a>';
-    };
-    return html.replace(/#([0-9]+)/g, replaceTicketLinks);
 }
 
 var loadCommitDetails = function(data)

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -288,6 +288,21 @@ var enableFeatures = function()
 	enableFeature("gravatar", $("committer_gravatar").parentNode)
 }
 
+/*
+Just add gitx.ticketurl to your repositories .git/config
+ 
+[gitx]
+ ticketurl = "http://trac.domain.com/ticket/*"
+
+*/
+var formatTicketUrls = function (html) {
+    var ticketUrl = Controller.getConfig_("gitx.ticketurl");
+    if (ticketUrl) {
+        return html.replace(/#([0-9]+)/g,'<a href="'+ticketUrl.replace("*","$1")+'" target="blank">#$1</a>');
+    }
+    return html;
+}
+
 var loadCommitDetails = function(data)
 {
 	commit.parseDetails(data);
@@ -317,7 +332,7 @@ var loadCommitDetails = function(data)
 		$("committerDate").parentNode.style.display = "none";
 	}
 
-	$("message").innerHTML = commit.message.replace(/\b(https?:\/\/[^\s<]*)/ig, "<a href=\"$1\">$1</a>").replace(/\n/g,"<br>");
+	$("message").innerHTML = formatTicketUrls(commit.message.replace(/\b(https?:\/\/[^\s<]*)/ig, "<a href=\"$1\">$1</a>").replace(/\n/g,"<br>"));
 
 	if (commit.diff.length < 200000)
 		showDiff();

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -296,26 +296,25 @@ Just add gitx.ticketurl to your repositories .git/config
 
 */
 var formatTicketUrls = function (html) {
-	var ticketUrl = Controller.getConfig_("gitx.ticketurl");
+    var ticketUrl = Controller.getConfig_("gitx.ticketurl");
     if (!ticketUrl) {
-       	var origin = Controller.getConfig_("remote.origin.url");
+        var origin = Controller.getConfig_("remote.origin.url");
         var matches = origin && origin.match(/github.com\/([^\/]+\/[^\/]+)\.git$/);
         if (matches) {
             ticketUrl = "https://github.com/"+matches[1]+"/issues/";
         }
     }
-	if (ticketUrl) {
-		var applyTicketUrl = ticketUrl.indexOf("{id}") >= 0 ? function (id) {
-			return ticketUrl.replace(/\{id\}/g,id);
-		} : function (id) {
-			return ticketUrl+""+id;
-		};
-        var replaceTicketLinks = function(match,id) {
-            return '<a class="ticket" href="'+applyTicketUrl(id)+'" target="blank">'+match+'</a>';
-        };
-		return html.replace(/#([0-9]+)/g, replaceTicketLinks);
-	}
-	return html;
+    var applyTicketUrl = (!ticketUrl) ? function (id) {
+        return '#configure-ticketurl';
+    } : (ticketUrl.indexOf("{id}") >= 0 ? function (id) {
+        return ticketUrl.replace(/\{id\}/g,id);
+    } : function (id) {
+        return ticketUrl+""+id;
+    });
+    var replaceTicketLinks = function(match,id) {
+        return '<a class="ticket" href="'+applyTicketUrl(id)+'" target="blank">'+match+'</a>';
+    };
+    return html.replace(/#([0-9]+)/g, replaceTicketLinks);
 }
 
 var loadCommitDetails = function(data)

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -296,11 +296,19 @@ Just add gitx.ticketurl to your repositories .git/config
 
 */
 var formatTicketUrls = function (html) {
-    var ticketUrl = Controller.getConfig_("gitx.ticketurl");
-    if (ticketUrl) {
-        return html.replace(/#([0-9]+)/g,'<a href="'+ticketUrl.replace("*","$1")+'" target="blank">#$1</a>');
     }
-    return html;
+	if (ticketUrl) {
+		var applyTicketUrl = ticketUrl.indexOf("{id}") >= 0 ? function (id) {
+			return ticketUrl.replace(/\{id\}/g,id);
+		} : function (id) {
+			return ticketUrl+""+id;
+		};
+        var replaceTicketLinks = function(match,id) {
+            return '<a class="ticket" href="'+applyTicketUrl(id)+'" target="blank">'+match+'</a>';
+        };
+		return html.replace(/#([0-9]+)/g, replaceTicketLinks);
+	}
+	return html;
 }
 
 var loadCommitDetails = function(data)

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -296,6 +296,13 @@ Just add gitx.ticketurl to your repositories .git/config
 
 */
 var formatTicketUrls = function (html) {
+	var ticketUrl = Controller.getConfig_("gitx.ticketurl");
+    if (!ticketUrl) {
+       	var origin = Controller.getConfig_("remote.origin.url");
+        var matches = origin && origin.match(/github.com\/([^\/]+\/[^\/]+)\.git$/);
+        if (matches) {
+            ticketUrl = "https://github.com/"+matches[1]+"/issues/";
+        }
     }
 	if (ticketUrl) {
 		var applyTicketUrl = ticketUrl.indexOf("{id}") >= 0 ? function (id) {

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -292,7 +292,7 @@ var enableFeatures = function()
 Just add gitx.ticketurl to your repositories .git/config
  
 [gitx]
- ticketurl = "http://trac.domain.com/ticket/*"
+ ticketurl = "http://trac.domain.com/ticket/{id}"
 
 */
 var formatTicketUrls = function (html) {


### PR DESCRIPTION
Adding this pull request in response to Issue #187. 

I added this a very long time ago to another fork of GitX. Now I rebased this commit onto GitX-dev master.

Here is how it works, just add `gitx.ticketurl` to your repositorys `.git/config`.

```
[gitx]
   ticketurl = "http://trac.example.org/ticket/{id}"
```

To point to github issues just use:

```
$ git config gitx.ticketurl 'https://github.com/rowanj/gitx/issues/{id}'
```

---

ToDo:
- [x] change pattern matching to: replace `{id}` or just append
- [x] auto detect GitHub "origin" for a default
- [x] always make  `#123` links, if not configured show message how to do it
- [x] change `[PBGitHistoryController showConfigureGitxTicketUrl]` to not only show a hint, instead let the user configure the Ticket URL right away... 

![configure-ticket-url](https://f.cloud.github.com/assets/26716/782779/7edc7a4c-ea41-11e2-924e-cff409a478d7.png)
