### PR TITLE
Don't crash when canceling the open panel for creating a new repository.

### DIFF
--- a/Classes/Controllers/PBRepositoryDocumentController.m
+++ b/Classes/Controllers/PBRepositoryDocumentController.m
@@ -34,8 +34,10 @@
 	[op setAllowsMultipleSelection:NO];
 	[op setMessage:@"Initialize a repository here:"];
 	[op setTitle:@"New Repository"];
-	if ([op runModal] != NSFileHandlingPanelOKButton)
+	if ([op runModal] != NSFileHandlingPanelOKButton) {
+        *outError = nil;
         return nil;
+    }
 
     BOOL success = [GTRepository initializeEmptyRepositoryAtURL:[op URL] error:outError];
     if (!success)


### PR DESCRIPTION
Fixed a crash when hitting cancel after trying to create a new repository.
