### PR TITLE
Gitx dev stashes

### DIFF
--- a/Classes/Controllers/PBGitCommitController.h
+++ b/Classes/Controllers/PBGitCommitController.h
@@ -33,4 +33,8 @@
 - (IBAction) commit:(id) sender;
 - (IBAction) forceCommit:(id) sender;
 - (IBAction)signOff:(id)sender;
+
+- (NSView *) nextKeyViewFor:(NSView *)view;
+- (NSView *) previousKeyViewFor:(NSView *)view;
+
 @end

--- a/Classes/Controllers/PBGitCommitController.h
+++ b/Classes/Controllers/PBGitCommitController.h
@@ -16,10 +16,14 @@
 	// This might have to transfer over to the PBGitRepository
 	// object sometime
 	PBGitIndex *index;
+    
+    BOOL stashKeepIndex;
 	
 	IBOutlet NSTextView *commitMessageView;
 	IBOutlet NSArrayController *unstagedFilesController;
 	IBOutlet NSArrayController *cachedFilesController;
+    
+    IBOutlet NSTabView *controlsTabView;
 	IBOutlet NSButton *commitButton;
 
 	IBOutlet PBGitIndexController *indexController;
@@ -28,9 +32,11 @@
 }
 
 @property(readonly) PBGitIndex *index;
+@property(assign) BOOL stashKeepIndex;
 
 - (IBAction) refresh:(id) sender;
 - (IBAction) commit:(id) sender;
 - (IBAction) forceCommit:(id) sender;
-- (IBAction)signOff:(id)sender;
+- (IBAction) signOff:(id)sender;
+- (IBAction) stashChanges:(id) sender;
 @end

--- a/Classes/Controllers/PBGitCommitController.h
+++ b/Classes/Controllers/PBGitCommitController.h
@@ -22,9 +22,11 @@
 	IBOutlet NSTextView *commitMessageView;
 	IBOutlet NSArrayController *unstagedFilesController;
 	IBOutlet NSArrayController *cachedFilesController;
+    IBOutlet NSArrayController *trackedFilesController;
     
     IBOutlet NSTabView *controlsTabView;
 	IBOutlet NSButton *commitButton;
+	IBOutlet NSButton *stashButton;
 
 	IBOutlet PBGitIndexController *indexController;
 	IBOutlet PBWebChangesController *webController;

--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -13,13 +13,14 @@
 #import "PBGitIndex.h"
 #import "PBNiceSplitView.h"
 #import "PBGitRepositoryWatcher.h"
+#import "PBGitIndexController.h"
 
 #import <ObjectiveGit/GTRepository.h>
 #import <ObjectiveGit/GTConfiguration.h>
 
 #define kCommitSplitViewPositionDefault @"Commit SplitView Position"
 
-@interface PBGitCommitController ()
+@interface PBGitCommitController () <NSTextViewDelegate>
 - (void)refreshFinished:(NSNotification *)notification;
 - (void)commitWithVerification:(BOOL) doVerify;
 - (void)commitStatusUpdated:(NSNotification *)notification;
@@ -60,6 +61,7 @@
 {
 	[super awakeFromNib];
 
+    commitMessageView.delegate = self;
 	[commitMessageView setTypingAttributes:[NSDictionary dictionaryWithObject:[NSFont fontWithName:@"Monaco" size:12.0] forKey:NSFontAttributeName]];
 	
 	[unstagedFilesController setFilterPredicate:[NSPredicate predicateWithFormat:@"hasUnstagedChanges == 1"]];
@@ -311,6 +313,59 @@
 
 	[commitSplitView setPosition:position ofDividerAtIndex:0];
 	[commitSplitView setHidden:NO];
+}
+
+#pragma mark NSTextView delegate methods
+
+- (void)focusTable:(NSTableView *)table
+{
+    if ([table numberOfRows] > 0) {
+        if ([table numberOfSelectedRows] == 0) {
+            [table selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
+        }
+        [[table window] makeFirstResponder:table];
+    }
+}
+
+- (BOOL)textView:(NSTextView *)textView doCommandBySelector:(SEL)commandSelector;
+{
+    if (commandSelector == @selector(insertTab:)) {
+        [self focusTable:indexController.stagedTable];
+        return YES;
+    } else if (commandSelector == @selector(insertBacktab:)) {
+        [self focusTable:indexController.unstagedTable];
+        return YES;
+	}
+    return NO;
+}
+
+# pragma mark Key View Chain
+
+-(NSView *)nextKeyViewFor:(NSView *)view
+{
+    NSView * next = nil;
+    if (view == indexController.unstagedTable) {
+        next = commitMessageView;
+    }
+    else if (view == commitMessageView) {
+        next = indexController.stagedTable;
+    }
+    else if (view == indexController.stagedTable) {
+        next = commitButton;
+    }
+    return next;
+}
+
+-(NSView *)previousKeyViewFor:(NSView *)view
+{
+    NSView * next = nil;
+    if (view == indexController.stagedTable) {
+        next = commitMessageView;
+    }
+    else if (view == commitMessageView) {
+        next = indexController.unstagedTable;
+    }
+    return next;
 }
 
 @end

--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -67,6 +67,7 @@
 	
 	[unstagedFilesController setFilterPredicate:[NSPredicate predicateWithFormat:@"hasUnstagedChanges == 1"]];
 	[cachedFilesController setFilterPredicate:[NSPredicate predicateWithFormat:@"hasStagedChanges == 1"]];
+    [trackedFilesController setFilterPredicate:[NSPredicate predicateWithFormat:@"status > 0"]];
 	
 	[unstagedFilesController setSortDescriptors:[NSArray arrayWithObjects:
 		[[NSSortDescriptor alloc] initWithKey:@"status" ascending:false],
@@ -237,12 +238,12 @@
 {
 	[cachedFilesController rearrangeObjects];
 	[unstagedFilesController rearrangeObjects];
-    if ([[cachedFilesController arrangedObjects] count]) {
-        [commitButton setEnabled:YES];
-    } else {
-        [commitButton setEnabled:NO];
-    }
-
+    
+    NSUInteger tracked = [[trackedFilesController arrangedObjects] count];
+    NSUInteger staged = [[cachedFilesController arrangedObjects] count];
+    
+    [commitButton setEnabled:(staged > 0)];
+    [stashButton setEnabled:(staged > 0 || tracked > 0)];
 }
 
 - (void)indexOperationFailed:(NSNotification *)notification

--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -144,6 +144,7 @@
 - (IBAction) stashChanges:(id)sender
 {
     NSLog(@"stash changes: %@", stashKeepIndex ? @"keep index" : @"");
+    [self.repository stashSaveWithKeepIndex:stashKeepIndex];
 }
 
 - (IBAction) commit:(id) sender

--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -18,6 +18,8 @@
 #import <ObjectiveGit/GTConfiguration.h>
 
 #define kCommitSplitViewPositionDefault @"Commit SplitView Position"
+#define kControlsTabIndexCommit 0
+#define kControlsTabIndexStash  1
 
 @interface PBGitCommitController ()
 - (void)refreshFinished:(NSNotification *)notification;
@@ -35,6 +37,7 @@
 @implementation PBGitCommitController
 
 @synthesize index;
+@synthesize stashKeepIndex;
 
 - (id)initWithRepository:(PBGitRepository *)theRepository superController:(PBGitWindowController *)controller
 {
@@ -123,6 +126,8 @@
 
 - (void) refresh:(id) sender
 {
+    [controlsTabView selectTabViewItemAtIndex:kControlsTabIndexCommit];
+    
 	self.isBusy = YES;
 	self.status = @"Refreshing index…";
 	[index refresh];
@@ -134,6 +139,11 @@
 - (void) updateView
 {
 	[self refresh:nil];
+}
+
+- (IBAction) stashChanges:(id)sender
+{
+    NSLog(@"stash changes: %@", stashKeepIndex ? @"keep index" : @"");
 }
 
 - (IBAction) commit:(id) sender
@@ -312,5 +322,19 @@
 	[commitSplitView setPosition:position ofDividerAtIndex:0];
 	[commitSplitView setHidden:NO];
 }
+
+#pragma mark Handle "alt" key-down/up events 
+// to toggle commit/stash controls
+
+- (void)flagsChanged:(NSEvent *)theEvent
+{
+    BOOL altDown = !!([theEvent modifierFlags] & NSAlternateKeyMask);
+    int currIndex = [controlsTabView indexOfTabViewItem:controlsTabView.selectedTabViewItem];
+    int desiredIndex = altDown ? kControlsTabIndexStash : kControlsTabIndexCommit;
+    if (currIndex != desiredIndex) {
+        [controlsTabView selectTabViewItemAtIndex:desiredIndex];
+    }
+}
+
 
 @end

--- a/Classes/Controllers/PBGitIndexController.h
+++ b/Classes/Controllers/PBGitIndexController.h
@@ -18,10 +18,16 @@
 	IBOutlet NSTableView *stagedTable;	
 }
 
+@property (readonly) NSTableView *unstagedTable;
+@property (readonly) NSTableView *stagedTable;
+
 - (IBAction) rowClicked:(NSCell *) sender;
 - (IBAction) tableClicked:(NSTableView *)tableView;
 
 - (NSMenu *) menuForTable:(NSTableView *)table;
+- (NSView *) nextKeyViewFor:(NSView *)view;
+- (NSView *) previousKeyViewFor:(NSView *)view;
+
 
 - (void) stageSelectedFiles;
 - (void) unstageSelectedFiles;

--- a/Classes/Controllers/PBGitIndexController.m
+++ b/Classes/Controllers/PBGitIndexController.m
@@ -19,6 +19,8 @@
 
 @implementation PBGitIndexController
 
+@synthesize stagedTable, unstagedTable;
+
 - (void)awakeFromNib
 {
 	[unstagedTable setDoubleAction:@selector(tableClicked:)];
@@ -384,6 +386,18 @@ writeRowsWithIndexes:(NSIndexSet *)rowIndexes
 		[commitController.index stageFiles:files];
 
 	return YES;
+}
+
+# pragma mark Key View Chain
+
+-(NSView *)nextKeyViewFor:(NSView *)view
+{
+    return [commitController nextKeyViewFor:view];
+}
+
+-(NSView *)previousKeyViewFor:(NSView *)view
+{
+    return [commitController previousKeyViewFor:view];
 }
 
 @end

--- a/Classes/Controllers/PBGitSidebarController.h
+++ b/Classes/Controllers/PBGitSidebarController.h
@@ -25,7 +25,7 @@
 	/* Specific things */
 	PBSourceViewItem *stage;
 
-	PBSourceViewItem *branches, *remotes, *tags, *others, *submodules;
+	PBSourceViewItem *branches, *remotes, *tags, *others, *submodules, *stashes;
 
 	PBGitHistoryController *historyViewController;
 	PBGitCommitController *commitViewController;

--- a/Classes/Controllers/PBGitSidebarController.m
+++ b/Classes/Controllers/PBGitSidebarController.m
@@ -16,6 +16,8 @@
 #import "PBAddRemoteSheet.h"
 #import "PBGitDefaults.h"
 #import "PBHistorySearchController.h"
+#import "PBGitStash.h"
+#import "PBGitSVStashItem.h"
 
 @interface PBGitSidebarController ()
 
@@ -288,9 +290,13 @@
 	branches = [PBSourceViewItem groupItemWithTitle:@"Branches"];
 	remotes = [PBSourceViewItem groupItemWithTitle:@"Remotes"];
 	tags = [PBSourceViewItem groupItemWithTitle:@"Tags"];
+    stashes = [PBSourceViewItem groupItemWithTitle:@"Stashes"];
 	submodules = [PBSourceViewItem groupItemWithTitle:@"Submodules"];
 	others = [PBSourceViewItem groupItemWithTitle:@"Other"];
 
+    for (PBGitStash *stash in repository.stashes)
+        [stashes addChild: [PBGitSVStashItem itemWithStash:stash]];
+    
 	for (PBGitRevSpecifier *rev in repository.branches)
 		[self addRevSpec:rev];
     
@@ -301,6 +307,7 @@
 	[items addObject:branches];
 	[items addObject:remotes];
 	[items addObject:tags];
+	[items addObject:stashes];
 	[items addObject:submodules];
 	[items addObject:others];
 
@@ -308,6 +315,7 @@
 	[sourceView expandItem:project];
 	[sourceView expandItem:branches expandChildren:YES];
 	[sourceView expandItem:remotes];
+    [sourceView expandItem:stashes];
     [sourceView expandItem:submodules];
 
 	[sourceView reloadItem:nil reloadChildren:YES];

--- a/Classes/Controllers/PBGitSidebarController.m
+++ b/Classes/Controllers/PBGitSidebarController.m
@@ -55,6 +55,7 @@
 
 	[repository addObserver:self forKeyPath:@"currentBranch" options:0 context:@"currentBranchChange"];
 	[repository addObserver:self forKeyPath:@"branches" options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) context:@"branchesModified"];
+   	[repository addObserver:self forKeyPath:@"stashes" options:0 context:@"stashesModified"];
 
     [sourceView setTarget:self];
     [sourceView setDoubleAction:@selector(doubleClicked:)];
@@ -84,6 +85,7 @@
 
 	[repository removeObserver:self forKeyPath:@"currentBranch"];
 	[repository removeObserver:self forKeyPath:@"branches"];
+	[repository removeObserver:self forKeyPath:@"stashes"];
 
 	[super closeView];
 }
@@ -114,6 +116,20 @@
 		}
 		return;
 	}
+    
+	if ([@"stashesModified" isEqualToString:(__bridge NSString*)context]) {
+        
+        for (PBGitSVStashItem *stashItem in stashes.sortedChildren)
+            [stashes removeChild:stashItem];
+        
+        for (PBGitStash *stash in repository.stashes)
+            [stashes addChild: [PBGitSVStashItem itemWithStash:stash]];
+
+        [sourceView expandItem:stashes];
+        [sourceView reloadItem:stashes reloadChildren:YES];
+        
+        return;
+    }
 
 	[super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
 }

--- a/Classes/Controllers/PBGitWindowController.h
+++ b/Classes/Controllers/PBGitWindowController.h
@@ -48,6 +48,9 @@
 - (IBAction) revealInFinder:(id)sender;
 - (IBAction) openInTerminal:(id)sender;
 - (IBAction) refresh:(id)sender;
+- (IBAction) stashSave:(id) sender;
+- (IBAction) stashSaveWithKeepIndex:(id) sender;
+- (IBAction) stashPop:(id) sender;
 
 - (void)setHistorySearch:(NSString *)searchString mode:(NSInteger)mode;
 

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -254,6 +254,27 @@
 	}
 }
 
+#pragma mark SplitView Delegates
+
+- (IBAction) stashSave:(id) sender
+{
+    [repository stashSaveWithKeepIndex:NO];
+}
+
+- (IBAction) stashSaveWithKeepIndex:(id) sender
+{
+    [repository stashSaveWithKeepIndex:YES];
+}
+
+- (IBAction) stashPop:(id) sender
+{
+    if ([repository.stashes count] > 0) {
+        PBGitStash * latestStash = [repository.stashes objectAtIndex:0];
+        [repository stashPop:latestStash];
+    }
+}
+
+
 #pragma mark -
 #pragma mark SplitView Delegates
 

--- a/Classes/Controllers/PBRefController.m
+++ b/Classes/Controllers/PBRefController.m
@@ -238,17 +238,29 @@
 
 -(void) stashPop:(id)sender
 {
-    NSLog(@"stashPop: %@", [sender refish]);
+    PBGitStash * stash = [historyController.repository stashForRef:[sender refish]];
+    BOOL ok = [historyController.repository stashPop:stash];
+    if (ok) {
+        [historyController.repository.windowController showCommitView:sender];
+    }
 }
 
 -(void) stashApply:(id)sender
 {
-    NSLog(@"stashApply: %@", [sender refish]);
+    PBGitStash * stash = [historyController.repository stashForRef:[sender refish]];
+    BOOL ok = [historyController.repository stashApply:stash];
+    if (ok) {
+        [historyController.repository.windowController showCommitView:sender];
+    }
 }
 
 -(void) stashDrop:(id)sender
 {
-    NSLog(@"stashDrop: %@", [sender refish]);
+    PBGitStash * stash = [historyController.repository stashForRef:[sender refish]];
+    BOOL ok = [historyController.repository stashDrop:stash];
+    if (ok) {
+        [historyController.repository.windowController showHistoryView:sender];
+    }
 }
 
 -(void) stashViewDiff:(id)sender

--- a/Classes/Controllers/PBRefController.m
+++ b/Classes/Controllers/PBRefController.m
@@ -234,6 +234,29 @@
 	[PBDiffWindowController showDiffWindowWithFiles:nil fromCommit:commit diffCommit:nil];
 }
 
+#pragma mark Stash
+
+-(void) stashPop:(id)sender
+{
+    NSLog(@"stashPop: %@", [sender refish]);
+}
+
+-(void) stashApply:(id)sender
+{
+    NSLog(@"stashApply: %@", [sender refish]);
+}
+
+-(void) stashDrop:(id)sender
+{
+    NSLog(@"stashDrop: %@", [sender refish]);
+}
+
+-(void) stashViewDiff:(id)sender
+{
+    PBGitStash * stash = [historyController.repository stashForRef:[sender refish]];
+    [PBDiffWindowController showDiffWindowWithFiles:nil fromCommit:stash.ancesterCommit diffCommit:stash.commit];
+}
+
 #pragma mark Tags
 
 - (void) createTag:(PBRefMenuItem *)sender

--- a/Classes/Views/PBFileChangesTableView.m
+++ b/Classes/Views/PBFileChangesTableView.m
@@ -70,4 +70,19 @@
     }
 }
 
+-(BOOL)acceptsFirstResponder
+{
+    return [self numberOfRows] > 0;
+}
+
+-(NSView *)nextKeyView
+{
+    return [(PBGitIndexController*)[self delegate] nextKeyViewFor:self];
+}
+
+-(NSView *)previousKeyView
+{
+    return [(PBGitIndexController*)[self delegate] previousKeyViewFor:self];
+}
+
 @end

--- a/Classes/Views/PBRefMenuItem.m
+++ b/Classes/Views/PBRefMenuItem.m
@@ -30,11 +30,48 @@
 }
 
 
++ (NSArray *) defaultMenuItemsForStashRef:(PBGitRef *)ref inRepository:(PBGitRepository *)repo target:(id)target
+{
+    NSMutableArray *items = [NSMutableArray array];
+	NSString *targetRefName = [ref shortName];
+    BOOL isCleanWorkingCopy = YES;
+    
+    // pop
+    NSString *stashPopTitle = [NSString stringWithFormat:@"Pop %@", targetRefName];
+    [items addObject:[PBRefMenuItem itemWithTitle:stashPopTitle action:@selector(stashPop:) enabled:isCleanWorkingCopy]];
+    
+    // apply
+    NSString *stashApplyTitle = @"Apply";
+    [items addObject:[PBRefMenuItem itemWithTitle:stashApplyTitle action:@selector(stashApply:) enabled:YES]];
+    
+    // view diff
+    NSString *stashDiffTitle = @"View Diff";
+    [items addObject:[PBRefMenuItem itemWithTitle:stashDiffTitle action:@selector(stashViewDiff:) enabled:YES]];
+
+    [items addObject:[PBRefMenuItem separatorItem]];
+
+    // drop
+    NSString *stashDropTitle = @"Drop";
+    [items addObject:[PBRefMenuItem itemWithTitle:stashDropTitle action:@selector(stashDrop:) enabled:YES]];
+    
+	for (PBRefMenuItem *item in items) {
+		[item setTarget:target];
+		[item setRefish:ref];
+	}
+    
+	return items;
+}
+
+
 + (NSArray *) defaultMenuItemsForRef:(PBGitRef *)ref inRepository:(PBGitRepository *)repo target:(id)target
 {
 	if (!ref || !repo || !target) {
 		return nil;
 	}
+    
+    if ([ref isStash]) {
+        return [self defaultMenuItemsForStashRef:ref inRepository:repo target:target];
+    }
 
 	NSMutableArray *items = [NSMutableArray array];
 

--- a/Classes/git/PBGitRef.h
+++ b/Classes/git/PBGitRef.h
@@ -14,10 +14,12 @@ extern NSString * const kGitXTagType;
 extern NSString * const kGitXBranchType;
 extern NSString * const kGitXRemoteType;
 extern NSString * const kGitXRemoteBranchType;
+extern NSString * const kGitXStashType;
 
 extern NSString * const kGitXTagRefPrefix;
 extern NSString * const kGitXBranchRefPrefix;
 extern NSString * const kGitXRemoteRefPrefix;
+extern NSString * const kGitXStashRefPrefix;
 
 
 @interface PBGitRef : NSObject <PBGitRefish> {
@@ -39,6 +41,7 @@ extern NSString * const kGitXRemoteRefPrefix;
 - (BOOL) isTag;
 - (BOOL) isRemote;
 - (BOOL) isRemoteBranch;
+- (BOOL) isStash;
 
 - (PBGitRef *) remoteRef;
 

--- a/Classes/git/PBGitRef.m
+++ b/Classes/git/PBGitRef.m
@@ -13,10 +13,12 @@ NSString * const kGitXTagType    = @"tag";
 NSString * const kGitXBranchType = @"branch";
 NSString * const kGitXRemoteType = @"remote";
 NSString * const kGitXRemoteBranchType = @"remote branch";
+NSString * const kGitXStashType  = @"stash";
 
 NSString * const kGitXTagRefPrefix    = @"refs/tags/";
 NSString * const kGitXBranchRefPrefix = @"refs/heads/";
 NSString * const kGitXRemoteRefPrefix = @"refs/remotes/";
+NSString * const kGitXStashRefPrefix  = @"refs/stash@";
 
 
 @implementation PBGitRef
@@ -63,6 +65,8 @@ NSString * const kGitXRemoteRefPrefix = @"refs/remotes/";
 		return @"tag";
 	if ([self isRemote])
 		return @"remote";
+	if ([self isStash])
+		return @"stash";
 	return nil;
 }
 
@@ -87,6 +91,11 @@ NSString * const kGitXRemoteRefPrefix = @"refs/remotes/";
 		return NO;
 
 	return ([[ref componentsSeparatedByString:@"/"] count] > 3);
+}
+
+- (BOOL) isStash
+{
+	return [ref hasPrefix:kGitXStashRefPrefix];
 }
 
 - (BOOL) isEqualToRef:(PBGitRef *)otherRef
@@ -132,6 +141,8 @@ NSString * const kGitXRemoteRefPrefix = @"refs/remotes/";
 
 - (NSString *) shortName
 {
+    if ([self isStash])
+        return [ref substringFromIndex:5];
 	if ([self type])
 		return [ref substringFromIndex:[[self type] length] + 7];
 	return ref;
@@ -147,6 +158,8 @@ NSString * const kGitXRemoteRefPrefix = @"refs/remotes/";
 		return kGitXRemoteBranchType;
 	if ([self isRemote])
 		return kGitXRemoteType;
+    if ([self isStash])
+        return kGitXStashType;
 	return nil;
 }
 

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -87,6 +87,8 @@ static NSString * PBStringFromBranchFilterType(PBGitXBranchFilterType type) {
 - (BOOL) stashPop:(PBGitStash *)stash;
 - (BOOL) stashApply:(PBGitStash *)stash;
 - (BOOL) stashDrop:(PBGitStash *)stash;
+- (BOOL) stashSave;
+- (BOOL) stashSaveWithKeepIndex:(BOOL)keepIndex;
 
 - (NSURL *) gitURL ;
 

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -10,6 +10,7 @@
 #import "PBGitHistoryList.h"
 #import "PBGitRevSpecifier.h"
 #import "PBGitRefish.h"
+#import "PBGitStash.h"
 
 @class GTRepository;
 @class GTConfiguration;
@@ -60,6 +61,7 @@ static NSString * PBStringFromBranchFilterType(PBGitXBranchFilterType type) {
 @property (readonly, getter = getIndexURL) NSURL* indexURL;
 
 @property (nonatomic, strong) PBGitHistoryList *revisionList;
+@property (nonatomic, readonly, strong) NSArray* stashes;
 @property (nonatomic, readonly, strong) NSArray* branches;
 @property (nonatomic, strong) NSMutableOrderedSet* branchesSet;
 @property (nonatomic, strong) PBGitRevSpecifier* currentBranch;
@@ -116,6 +118,7 @@ static NSString * PBStringFromBranchFilterType(PBGitXBranchFilterType type) {
 - (PBGitSHA *)shaForRef:(PBGitRef *)ref;
 - (PBGitCommit *)commitForRef:(PBGitRef *)ref;
 - (PBGitCommit *)commitForSHA:(PBGitSHA *)sha;
+- (PBGitStash *)stashForRef:(PBGitRef *)ref;
 - (BOOL)isOnSameBranch:(PBGitSHA *)baseSHA asSHA:(PBGitSHA *)testSHA;
 - (BOOL)isSHAOnHeadBranch:(PBGitSHA *)testSHA;
 - (BOOL)isRefOnHeadBranch:(PBGitRef *)testRef;

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -84,6 +84,9 @@ static NSString * PBStringFromBranchFilterType(PBGitXBranchFilterType type) {
 - (BOOL) createTag:(NSString *)tagName message:(NSString *)message atRefish:(id <PBGitRefish>)commitSHA;
 - (BOOL) deleteRemote:(PBGitRef *)ref;
 - (BOOL) deleteRef:(PBGitRef *)ref;
+- (BOOL) stashPop:(PBGitStash *)stash;
+- (BOOL) stashApply:(PBGitStash *)stash;
+- (BOOL) stashDrop:(PBGitStash *)stash;
 
 - (NSURL *) gitURL ;
 

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -636,6 +636,21 @@ static int stashEnumerationCallback(size_t index,
     return [self stashRunCommand:@"drop" withStash:stash];
 }
 
+-(BOOL)stashSave
+{
+    return [self stashSaveWithKeepIndex:NO];
+}
+
+-(BOOL)stashSaveWithKeepIndex:(BOOL)keepIndex
+{
+    NSArray * args = @[@"stash", @"save", keepIndex?@"--keep-index":@"--no-keep-index"];
+    int retValue;
+    NSString * output = [self outputInWorkdirForArguments:args retValue:&retValue];
+    [self willChangeValueForKey:@"stashes"];
+	[self didChangeValueForKey:@"stashes"];
+    return retValue ? NO : YES;
+}
+
 #pragma mark Remotes
 
 - (NSArray *) remotes

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -612,7 +612,29 @@ static int stashEnumerationCallback(size_t index,
     return found;
 }
 
+-(BOOL)stashRunCommand:(NSString *)command withStash:(PBGitStash *)stash
+{
+    int retValue;
+    [self outputInWorkdirForArguments:@[@"stash", command, stash.ref.refishName] retValue:&retValue];
+    [self willChangeValueForKey:@"stashes"];
+	[self didChangeValueForKey:@"stashes"];
+    return retValue ? NO : YES;
+}
 
+-(BOOL)stashPop:(PBGitStash *)stash
+{
+    return [self stashRunCommand:@"pop" withStash:stash];
+}
+
+-(BOOL)stashApply:(PBGitStash *)stash
+{
+    return [self stashRunCommand:@"apply" withStash:stash];
+}
+
+-(BOOL)stashDrop:(PBGitStash *)stash
+{
+    return [self stashRunCommand:@"drop" withStash:stash];
+}
 
 #pragma mark Remotes
 

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -294,7 +294,9 @@ int addSubmoduleName(git_submodule *module, const char* name, void * context)
     [self loadSubmodules];
     
 	[self willChangeValueForKey:@"refs"];
+	[self willChangeValueForKey:@"stashes"];
 	[self didChangeValueForKey:@"refs"];
+	[self didChangeValueForKey:@"stashes"];
 
 	[[[self windowController] window] setTitle:[self displayName]];
 }

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -615,9 +615,15 @@ static int stashEnumerationCallback(size_t index,
 -(BOOL)stashRunCommand:(NSString *)command withStash:(PBGitStash *)stash
 {
     int retValue;
-    [self outputInWorkdirForArguments:@[@"stash", command, stash.ref.refishName] retValue:&retValue];
+    NSArray *arguments = @[@"stash", command, stash.ref.refishName];
+	NSString *output = [self outputInWorkdirForArguments:arguments retValue:&retValue];
     [self willChangeValueForKey:@"stashes"];
 	[self didChangeValueForKey:@"stashes"];
+	if (retValue) {
+		NSString *title = [NSString stringWithFormat:@"Stash %@ failed!", command];
+		NSString *message = [NSString stringWithFormat:@"There was an error!"];
+		[self.windowController showErrorSheetTitle:title message:message arguments:arguments output:output];
+    }
     return retValue ? NO : YES;
 }
 
@@ -643,11 +649,16 @@ static int stashEnumerationCallback(size_t index,
 
 -(BOOL)stashSaveWithKeepIndex:(BOOL)keepIndex
 {
-    NSArray * args = @[@"stash", @"save", keepIndex?@"--keep-index":@"--no-keep-index"];
     int retValue;
-    NSString * output = [self outputInWorkdirForArguments:args retValue:&retValue];
+    NSArray * arguments = @[@"stash", @"save", keepIndex?@"--keep-index":@"--no-keep-index"];
+    NSString * output = [self outputInWorkdirForArguments:arguments retValue:&retValue];
     [self willChangeValueForKey:@"stashes"];
 	[self didChangeValueForKey:@"stashes"];
+    if (retValue) {
+		NSString *title = [NSString stringWithFormat:@"Stash save failed!"];
+		NSString *message = [NSString stringWithFormat:@"There was an error!"];
+		[self.windowController showErrorSheetTitle:title message:message arguments:arguments output:output];
+    }
     return retValue ? NO : YES;
 }
 

--- a/Classes/git/PBGitSVStashItem.h
+++ b/Classes/git/PBGitSVStashItem.h
@@ -1,0 +1,19 @@
+//
+//  PBSourceViewStash.h
+//  GitX
+//
+//  Created by Mathias Leppich on 8/1/13.
+//
+//
+
+#import <Cocoa/Cocoa.h>
+#import "PBSourceViewItem.h"
+#import "PBGitStash.h"
+
+@interface PBGitSVStashItem : PBSourceViewItem
+
++ (id) itemWithStash:(PBGitStash*)stash;
+
+@property (nonatomic, strong) PBGitStash* stash;
+
+@end

--- a/Classes/git/PBGitSVStashItem.m
+++ b/Classes/git/PBGitSVStashItem.m
@@ -1,0 +1,28 @@
+//
+//  PBSourceViewStash.m
+//  GitX
+//
+//  Created by Mathias Leppich on 8/1/13.
+//
+//
+
+#import "PBGitSVStashItem.h"
+#import "PBGitRevSpecifier.h"
+
+
+@implementation PBGitSVStashItem
+
++ (id)itemWithStash:(PBGitStash *)stash
+{
+    NSString * title = [NSString stringWithFormat:@"@{%zd}: %@", stash.index, stash.message];
+    PBGitSVStashItem * item = [self itemWithTitle:title];
+    item.stash = stash;
+    item.revSpecifier = [[PBGitRevSpecifier alloc] initWithRef:stash.ref];
+    return item;
+}
+
+-(PBGitRef *)ref {
+    return self.stash.ref;
+}
+
+@end

--- a/Classes/git/PBGitStash.h
+++ b/Classes/git/PBGitStash.h
@@ -1,0 +1,27 @@
+//
+//  PBGitStash.h
+//  GitX
+//
+//  Created by Mathias Leppich on 8/1/13.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <ObjectiveGit/ObjectiveGit.h>
+
+@class PBGitCommit;
+@class PBGitRef;
+@class PBGitRepository;
+
+@interface PBGitStash : NSObject
+@property (nonatomic, readonly) size_t index;
+@property (nonatomic, readonly) PBGitCommit * commit;
+@property (nonatomic, readonly) NSString* message;
+@property (nonatomic, readonly) PBGitRef* ref;
+
+@property (nonatomic, readonly) PBGitCommit * indexCommit;
+@property (nonatomic, readonly) PBGitCommit * ancesterCommit;
+
+- (id) initWithRepository:(PBGitRepository *)repo stashOID:(git_oid)stash_id index:(size_t)index message:(NSString *)message;
+
+@end

--- a/Classes/git/PBGitStash.m
+++ b/Classes/git/PBGitStash.m
@@ -39,7 +39,7 @@
     _indexCommit = [PBGitCommit commitWithRepository:repo andSha:indexSha];
     _ancesterCommit = [PBGitCommit commitWithRepository:repo andSha:ancestorSha];
     
-    NSLog(@" stash: %zd, %@, %@, %@",_index,[_commit shortName], [_ancesterCommit  shortName], [_indexCommit shortName]);
+    //NSLog(@" stash: %zd, %@, %@, %@",_index,[_commit shortName], [_ancesterCommit  shortName], [_indexCommit shortName]);
     return self;
 }
 

--- a/Classes/git/PBGitStash.m
+++ b/Classes/git/PBGitStash.m
@@ -1,0 +1,57 @@
+//
+//  PBGitStash.m
+//  GitX
+//
+//  Created by Mathias Leppich on 8/1/13.
+//
+//
+
+#import "PBGitStash.h"
+#import "PBGitRef.h"
+#import "PBGitCommit.h"
+#import <git2.h>
+
+@implementation PBGitStash
+
+@synthesize index = _index;
+@synthesize commit = _commit;
+@synthesize message = _message;
+@synthesize indexCommit = _indexCommit;
+@synthesize ancesterCommit = _ancesterCommit;
+
+-(id)initWithRepository:(PBGitRepository *)repo stashOID:(git_oid)stash_id index:(size_t)index message:(NSString *)message
+{
+    _index = index;
+    _message = message;
+    
+    GTRepository * gtRepo = repo.gtRepo;
+    NSError * error = nil;
+    GTCommit * gtCommit = (GTCommit *)[gtRepo lookupObjectByOid:&stash_id objectType:GTObjectTypeCommit error:&error];
+    NSArray * parents = [gtCommit parents];
+    GTCommit * gtIndexCommit = [parents objectAtIndex:1];
+    GTCommit * gtAncestorCommit = [parents objectAtIndex:0];
+    
+    PBGitSHA * sha = [PBGitSHA shaWithOID:stash_id];
+    PBGitSHA * indexSha = [PBGitSHA shaWithOID:*git_object_id(gtIndexCommit.git_object)];
+    PBGitSHA * ancestorSha = [PBGitSHA shaWithOID:*git_object_id(gtAncestorCommit.git_object)];
+    
+    _commit = [PBGitCommit commitWithRepository:repo andSha:sha];
+    _indexCommit = [PBGitCommit commitWithRepository:repo andSha:indexSha];
+    _ancesterCommit = [PBGitCommit commitWithRepository:repo andSha:ancestorSha];
+    
+    NSLog(@" stash: %zd, %@, %@, %@",_index,[_commit shortName], [_ancesterCommit  shortName], [_indexCommit shortName]);
+    return self;
+}
+
+-(NSString *)description
+{
+    return [NSString stringWithFormat:@"stash@{%zd}: %@", _index, _message];
+}
+
+-(PBGitRef *)ref
+{
+    NSString * refStr = [NSString stringWithFormat:@"refs/stash@{%zd}", _index];
+    return [[PBGitRef alloc] initWithString:refStr];
+}
+
+@end

--- a/English.lproj/MainMenu.xib
+++ b/English.lproj/MainMenu.xib
@@ -700,6 +700,44 @@
 									<reference key="NSOnImage" ref="889736156"/>
 									<reference key="NSMixedImage" ref="37108609"/>
 								</object>
+								<object class="NSMenuItem" id="1064994735">
+									<reference key="NSMenu" ref="944982980"/>
+									<string key="NSTitle">Stash Save</string>
+									<string key="NSKeyEquiv">y</string>
+									<int key="NSKeyEquivModMask">1048576</int>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="889736156"/>
+									<reference key="NSMixedImage" ref="37108609"/>
+								</object>
+								<object class="NSMenuItem" id="1015461029">
+									<reference key="NSMenu" ref="944982980"/>
+									<bool key="NSIsAlternate">YES</bool>
+									<string key="NSTitle">Stash Save - Keep Index</string>
+									<string key="NSKeyEquiv">y</string>
+									<int key="NSKeyEquivModMask">1572864</int>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="889736156"/>
+									<reference key="NSMixedImage" ref="37108609"/>
+								</object>
+								<object class="NSMenuItem" id="527546620">
+									<reference key="NSMenu" ref="944982980"/>
+									<string key="NSTitle">Stash Pop</string>
+									<string key="NSKeyEquiv">Y</string>
+									<int key="NSKeyEquivModMask">1048576</int>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="889736156"/>
+									<reference key="NSMixedImage" ref="37108609"/>
+								</object>
+								<object class="NSMenuItem" id="10133429">
+									<reference key="NSMenu" ref="944982980"/>
+									<bool key="NSIsDisabled">YES</bool>
+									<bool key="NSIsSeparator">YES</bool>
+									<string key="NSTitle"/>
+									<string key="NSKeyEquiv"/>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="889736156"/>
+									<reference key="NSMixedImage" ref="37108609"/>
+								</object>
 								<object class="NSMenuItem" id="298101952">
 									<reference key="NSMenu" ref="944982980"/>
 									<string key="NSTitle">Open in Terminal</string>
@@ -1319,6 +1357,30 @@
 						<reference key="destination" ref="219112383"/>
 					</object>
 					<int key="connectionID">968</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">stashSave:</string>
+						<reference key="source" ref="954860085"/>
+						<reference key="destination" ref="1064994735"/>
+					</object>
+					<int key="connectionID">990</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">stashSaveWithKeepIndex:</string>
+						<reference key="source" ref="954860085"/>
+						<reference key="destination" ref="1015461029"/>
+					</object>
+					<int key="connectionID">991</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">stashPop:</string>
+						<reference key="source" ref="954860085"/>
+						<reference key="destination" ref="527546620"/>
+					</object>
+					<int key="connectionID">992</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBActionConnection" key="connection">
@@ -2017,10 +2079,14 @@
 						<array class="NSMutableArray" key="children">
 							<reference ref="81071151"/>
 							<reference ref="298101952"/>
-							<reference ref="255856917"/>
 							<reference ref="950917510"/>
 							<reference ref="416044880"/>
 							<reference ref="173376826"/>
+							<reference ref="255856917"/>
+							<reference ref="10133429"/>
+							<reference ref="1064994735"/>
+							<reference ref="1015461029"/>
+							<reference ref="527546620"/>
 						</array>
 						<reference key="parent" ref="571164270"/>
 					</object>
@@ -2032,11 +2098,6 @@
 					<object class="IBObjectRecord">
 						<int key="objectID">942</int>
 						<reference key="object" ref="298101952"/>
-						<reference key="parent" ref="944982980"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">943</int>
-						<reference key="object" ref="255856917"/>
 						<reference key="parent" ref="944982980"/>
 					</object>
 					<object class="IBObjectRecord">
@@ -2084,6 +2145,31 @@
 						<reference key="object" ref="470951640"/>
 						<reference key="parent" ref="612917469"/>
 						<string key="objectName">Menu Item - Change Log</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">977</int>
+						<reference key="object" ref="255856917"/>
+						<reference key="parent" ref="944982980"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">986</int>
+						<reference key="object" ref="10133429"/>
+						<reference key="parent" ref="944982980"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">987</int>
+						<reference key="object" ref="1064994735"/>
+						<reference key="parent" ref="944982980"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">988</int>
+						<reference key="object" ref="1015461029"/>
+						<reference key="parent" ref="944982980"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">989</int>
+						<reference key="object" ref="527546620"/>
+						<reference key="parent" ref="944982980"/>
 					</object>
 				</array>
 			</object>
@@ -2185,7 +2271,6 @@
 				<string key="937.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="938.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="942.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="943.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="947.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="949.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="951.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -2195,12 +2280,17 @@
 				<string key="969.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="972.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="974.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="977.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="986.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="987.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="988.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="989.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 			</dictionary>
 			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">976</int>
+			<int key="maxID">992</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -2211,7 +2301,6 @@
 						<string key="installCliTool:">id</string>
 						<string key="openPreferencesWindow:">id</string>
 						<string key="reportAProblem:">id</string>
-						<string key="saveAction:">id</string>
 						<string key="showAboutPanel:">id</string>
 						<string key="showChangeLog:">id</string>
 						<string key="showCloneRepository:">id</string>
@@ -2228,10 +2317,6 @@
 						</object>
 						<object class="IBActionInfo" key="reportAProblem:">
 							<string key="name">reportAProblem:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="saveAction:">
-							<string key="name">saveAction:</string>
 							<string key="candidateClassName">id</string>
 						</object>
 						<object class="IBActionInfo" key="showAboutPanel:">
@@ -2364,47 +2449,6 @@
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">
-					<string key="className">NSDocument</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="printDocument:">id</string>
-						<string key="revertDocumentToSaved:">id</string>
-						<string key="runPageLayout:">id</string>
-						<string key="saveDocument:">id</string>
-						<string key="saveDocumentAs:">id</string>
-						<string key="saveDocumentTo:">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="printDocument:">
-							<string key="name">printDocument:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="revertDocumentToSaved:">
-							<string key="name">revertDocumentToSaved:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="runPageLayout:">
-							<string key="name">runPageLayout:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="saveDocument:">
-							<string key="name">saveDocument:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="saveDocumentAs:">
-							<string key="name">saveDocumentAs:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="saveDocumentTo:">
-							<string key="name">saveDocumentTo:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/NSDocument.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
 					<string key="className">PBCollapsibleSplitView</string>
 					<string key="superclassName">PBNiceSplitView</string>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
@@ -2529,6 +2573,7 @@
 						<string key="forceCommit:">id</string>
 						<string key="refresh:">id</string>
 						<string key="signOff:">id</string>
+						<string key="stashChanges:">id</string>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="actionInfosByName">
 						<object class="IBActionInfo" key="commit:">
@@ -2547,13 +2592,20 @@
 							<string key="name">signOff:</string>
 							<string key="candidateClassName">id</string>
 						</object>
+						<object class="IBActionInfo" key="stashChanges:">
+							<string key="name">stashChanges:</string>
+							<string key="candidateClassName">id</string>
+						</object>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="outlets">
 						<string key="cachedFilesController">NSArrayController</string>
 						<string key="commitButton">NSButton</string>
 						<string key="commitMessageView">NSTextView</string>
 						<string key="commitSplitView">PBNiceSplitView</string>
+						<string key="controlsTabView">NSTabView</string>
 						<string key="indexController">PBGitIndexController</string>
+						<string key="stashButton">NSButton</string>
+						<string key="trackedFilesController">NSArrayController</string>
 						<string key="unstagedFilesController">NSArrayController</string>
 						<string key="webController">PBWebChangesController</string>
 					</dictionary>
@@ -2574,9 +2626,21 @@
 							<string key="name">commitSplitView</string>
 							<string key="candidateClassName">PBNiceSplitView</string>
 						</object>
+						<object class="IBToOneOutletInfo" key="controlsTabView">
+							<string key="name">controlsTabView</string>
+							<string key="candidateClassName">NSTabView</string>
+						</object>
 						<object class="IBToOneOutletInfo" key="indexController">
 							<string key="name">indexController</string>
 							<string key="candidateClassName">PBGitIndexController</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="stashButton">
+							<string key="name">stashButton</string>
+							<string key="candidateClassName">NSButton</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="trackedFilesController">
+							<string key="name">trackedFilesController</string>
+							<string key="candidateClassName">NSArrayController</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="unstagedFilesController">
 							<string key="name">unstagedFilesController</string>
@@ -2841,6 +2905,9 @@
 						<string key="revealInFinder:">id</string>
 						<string key="showCommitView:">id</string>
 						<string key="showHistoryView:">id</string>
+						<string key="stashPop:">id</string>
+						<string key="stashSave:">id</string>
+						<string key="stashSaveWithKeepIndex:">id</string>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="actionInfosByName">
 						<object class="IBActionInfo" key="openInTerminal:">
@@ -2861,6 +2928,18 @@
 						</object>
 						<object class="IBActionInfo" key="showHistoryView:">
 							<string key="name">showHistoryView:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+						<object class="IBActionInfo" key="stashPop:">
+							<string key="name">stashPop:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+						<object class="IBActionInfo" key="stashSave:">
+							<string key="name">stashSave:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+						<object class="IBActionInfo" key="stashSaveWithKeepIndex:">
+							<string key="name">stashSaveWithKeepIndex:</string>
 							<string key="candidateClassName">id</string>
 						</object>
 					</dictionary>
@@ -3148,24 +3227,6 @@
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
 						<string key="minorKey">./Classes/SUUpdater.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">WebView</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">reloadFromOrigin:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">reloadFromOrigin:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">reloadFromOrigin:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/WebView.h</string>
 					</object>
 				</object>
 			</array>

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		911112370E5A097800BF76B4 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 911112360E5A097800BF76B4 /* Security.framework */; };
 		913D5E500E55645900CECEA2 /* gitx in Resources */ = {isa = PBXBuildFile; fileRef = 913D5E490E55644600CECEA2 /* gitx */; };
+		A2F8D0DF17AAB32500580B84 /* PBGitStash.m in Sources */ = {isa = PBXBuildFile; fileRef = A2F8D0DE17AAB32500580B84 /* PBGitStash.m */; };
 		BC0444AD17648CC900353E6D /* AddRemoteTemplate.png in Resources */ = {isa = PBXBuildFile; fileRef = BC0444AC17648CC900353E6D /* AddRemoteTemplate.png */; };
 		BC0444B817648D0200353E6D /* BranchHighlighted.png in Resources */ = {isa = PBXBuildFile; fileRef = BC0444B717648D0200353E6D /* BranchHighlighted.png */; };
 		BC0444BA17648DA800353E6D /* FolderHighlighted.png in Resources */ = {isa = PBXBuildFile; fileRef = BC0444B917648DA700353E6D /* FolderHighlighted.png */; };
@@ -644,6 +645,8 @@
 		8D1107320486CEB800E47090 /* GitX.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitX.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		911112360E5A097800BF76B4 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = /System/Library/Frameworks/Security.framework; sourceTree = "<absolute>"; };
 		913D5E490E55644600CECEA2 /* gitx */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = gitx; sourceTree = BUILT_PRODUCTS_DIR; };
+		A2F8D0DD17AAB32500580B84 /* PBGitStash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGitStash.h; sourceTree = "<group>"; };
+		A2F8D0DE17AAB32500580B84 /* PBGitStash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGitStash.m; sourceTree = "<group>"; };
 		BC0444AC17648CC900353E6D /* AddRemoteTemplate.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AddRemoteTemplate.png; sourceTree = "<group>"; };
 		BC0444B717648D0200353E6D /* BranchHighlighted.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = BranchHighlighted.png; sourceTree = "<group>"; };
 		BC0444B917648DA700353E6D /* FolderHighlighted.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = FolderHighlighted.png; sourceTree = "<group>"; };
@@ -1093,6 +1096,8 @@
 				4A5D768414A9A9CC00DF6C68 /* PBGitXProtocol.m */,
 				643952721603E9BC00BB7AFF /* PBGitSubmodule.h */,
 				643952731603E9BC00BB7AFF /* PBGitSubmodule.m */,
+				A2F8D0DD17AAB32500580B84 /* PBGitStash.h */,
+				A2F8D0DE17AAB32500580B84 /* PBGitStash.m */,
 				643952751603EF9B00BB7AFF /* PBGitSVSubmoduleItem.h */,
 				643952761603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m */,
 				4AB057E11652652000DE751D /* GitRepoFinder.h */,
@@ -1642,6 +1647,7 @@
 				643952741603E9BC00BB7AFF /* PBGitSubmodule.m in Sources */,
 				643952771603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m in Sources */,
 				4AB057E31652652000DE751D /* GitRepoFinder.m in Sources */,
+				A2F8D0DF17AAB32500580B84 /* PBGitStash.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		911112370E5A097800BF76B4 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 911112360E5A097800BF76B4 /* Security.framework */; };
 		913D5E500E55645900CECEA2 /* gitx in Resources */ = {isa = PBXBuildFile; fileRef = 913D5E490E55644600CECEA2 /* gitx */; };
 		A2F8D0DF17AAB32500580B84 /* PBGitStash.m in Sources */ = {isa = PBXBuildFile; fileRef = A2F8D0DE17AAB32500580B84 /* PBGitStash.m */; };
+		A2F8D0EB17AAB95E00580B84 /* PBGitSVStashItem.m in Sources */ = {isa = PBXBuildFile; fileRef = A2F8D0EA17AAB95E00580B84 /* PBGitSVStashItem.m */; };
 		BC0444AD17648CC900353E6D /* AddRemoteTemplate.png in Resources */ = {isa = PBXBuildFile; fileRef = BC0444AC17648CC900353E6D /* AddRemoteTemplate.png */; };
 		BC0444B817648D0200353E6D /* BranchHighlighted.png in Resources */ = {isa = PBXBuildFile; fileRef = BC0444B717648D0200353E6D /* BranchHighlighted.png */; };
 		BC0444BA17648DA800353E6D /* FolderHighlighted.png in Resources */ = {isa = PBXBuildFile; fileRef = BC0444B917648DA700353E6D /* FolderHighlighted.png */; };
@@ -647,6 +648,8 @@
 		913D5E490E55644600CECEA2 /* gitx */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = gitx; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2F8D0DD17AAB32500580B84 /* PBGitStash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGitStash.h; sourceTree = "<group>"; };
 		A2F8D0DE17AAB32500580B84 /* PBGitStash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGitStash.m; sourceTree = "<group>"; };
+		A2F8D0E917AAB95E00580B84 /* PBGitSVStashItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGitSVStashItem.h; sourceTree = "<group>"; };
+		A2F8D0EA17AAB95E00580B84 /* PBGitSVStashItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGitSVStashItem.m; sourceTree = "<group>"; };
 		BC0444AC17648CC900353E6D /* AddRemoteTemplate.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AddRemoteTemplate.png; sourceTree = "<group>"; };
 		BC0444B717648D0200353E6D /* BranchHighlighted.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = BranchHighlighted.png; sourceTree = "<group>"; };
 		BC0444B917648DA700353E6D /* FolderHighlighted.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = FolderHighlighted.png; sourceTree = "<group>"; };
@@ -1088,6 +1091,8 @@
 				4A5D767C14A9A9CC00DF6C68 /* PBGitSVStageItem.m */,
 				4A5D767D14A9A9CC00DF6C68 /* PBGitSVTagItem.h */,
 				4A5D767E14A9A9CC00DF6C68 /* PBGitSVTagItem.m */,
+				A2F8D0E917AAB95E00580B84 /* PBGitSVStashItem.h */,
+				A2F8D0EA17AAB95E00580B84 /* PBGitSVStashItem.m */,
 				4A5D767F14A9A9CC00DF6C68 /* PBGitTree.h */,
 				4A5D768014A9A9CC00DF6C68 /* PBGitTree.m */,
 				4A5D768114A9A9CC00DF6C68 /* PBGitXErrors.h */,
@@ -1648,6 +1653,7 @@
 				643952771603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m in Sources */,
 				4AB057E31652652000DE751D /* GitRepoFinder.m in Sources */,
 				A2F8D0DF17AAB32500580B84 /* PBGitStash.m in Sources */,
+				A2F8D0EB17AAB95E00580B84 /* PBGitSVStashItem.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resources/XIBs/PBGitCommitView.xib
+++ b/Resources/XIBs/PBGitCommitView.xib
@@ -2,13 +2,13 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1060</int>
-		<string key="IBDocument.SystemVersion">12A269</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2549</string>
-		<string key="IBDocument.AppKitVersion">1187</string>
-		<string key="IBDocument.HIToolboxVersion">624.00</string>
+		<string key="IBDocument.SystemVersion">12E55</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.39</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<dictionary class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="com.apple.InterfaceBuilder.CocoaPlugin">2549</string>
-			<string key="com.apple.WebKitIBPlugin">1460</string>
+			<string key="com.apple.InterfaceBuilder.CocoaPlugin">3084</string>
+			<string key="com.apple.WebKitIBPlugin">2053</string>
 		</dictionary>
 		<array key="IBDocument.IntegratedClassDependencies">
 			<string>NSArrayController</string>
@@ -20,11 +20,14 @@
 			<string>NSScrollView</string>
 			<string>NSScroller</string>
 			<string>NSSplitView</string>
+			<string>NSTabView</string>
+			<string>NSTabViewItem</string>
 			<string>NSTableColumn</string>
 			<string>NSTableView</string>
 			<string>NSTextFieldCell</string>
 			<string>NSTextView</string>
 			<string>NSUserDefaultsController</string>
+			<string>NSView</string>
 			<string>WebView</string>
 		</array>
 		<array key="IBDocument.PluginDependencies">
@@ -298,33 +301,6 @@
 												<reference key="NSNextResponder" ref="635871052"/>
 												<int key="NSvFlags">274</int>
 												<array class="NSMutableArray" key="NSSubviews">
-													<object class="NSButton" id="792511503">
-														<reference key="NSNextResponder" ref="154221104"/>
-														<int key="NSvFlags">289</int>
-														<string key="NSFrame">{{339, 0}, {96, 32}}</string>
-														<reference key="NSSuperview" ref="154221104"/>
-														<reference key="NSWindow"/>
-														<reference key="NSNextKeyView" ref="955377287"/>
-														<bool key="NSEnabled">YES</bool>
-														<object class="NSButtonCell" key="NSCell" id="767461980">
-															<int key="NSCellFlags">67108864</int>
-															<int key="NSCellFlags2">134217728</int>
-															<string key="NSContents">Commit</string>
-															<object class="NSFont" key="NSSupport" id="554612341">
-																<string key="NSName">LucidaGrande</string>
-																<double key="NSSize">13</double>
-																<int key="NSfFlags">1044</int>
-															</object>
-															<reference key="NSControlView" ref="792511503"/>
-															<int key="NSButtonFlags">-2038284288</int>
-															<int key="NSButtonFlags2">268435585</int>
-															<string key="NSAlternateContents"/>
-															<string type="base64-UTF8" key="NSKeyEquivalent">DQ</string>
-															<int key="NSPeriodicDelay">200</int>
-															<int key="NSPeriodicInterval">25</int>
-														</object>
-														<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-													</object>
 													<object class="NSScrollView" id="227052526">
 														<reference key="NSNextResponder" ref="154221104"/>
 														<int key="NSvFlags">274</int>
@@ -378,7 +354,7 @@
 																			<int key="NSTCFlags">1</int>
 																		</object>
 																		<object class="NSTextViewSharedData" key="NSSharedData">
-																			<int key="NSFlags">298883</int>
+																			<int key="NSFlags">67407747</int>
 																			<int key="NSTextCheckingTypes">0</int>
 																			<nil key="NSMarkedAttributes"/>
 																			<reference key="NSBackgroundColor" ref="818038086"/>
@@ -446,7 +422,7 @@
 																<string key="NSFrame">{{346, 1}, {15, 164}}</string>
 																<reference key="NSSuperview" ref="227052526"/>
 																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="18874447"/>
+																<reference key="NSNextKeyView" ref="312803625"/>
 																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 																<reference key="NSTarget" ref="227052526"/>
 																<string key="NSAction">_doScroller:</string>
@@ -479,58 +455,193 @@
 														<double key="NSMaxMagnification">4</double>
 														<double key="NSMagnification">1</double>
 													</object>
-													<object class="NSButton" id="18874447">
+													<object class="NSTabView" id="312803625">
 														<reference key="NSNextResponder" ref="154221104"/>
-														<int key="NSvFlags">292</int>
-														<string key="NSFrame">{{-2, 9}, {82, 18}}</string>
+														<int key="NSvFlags">34</int>
+														<string key="NSFrame">{{0, 4}, {429, 30}}</string>
 														<reference key="NSSuperview" ref="154221104"/>
 														<reference key="NSWindow"/>
-														<reference key="NSNextKeyView" ref="1042222292"/>
-														<bool key="NSEnabled">YES</bool>
-														<object class="NSButtonCell" key="NSCell" id="475684116">
-															<int key="NSCellFlags">-2080374784</int>
-															<int key="NSCellFlags2">0</int>
-															<string key="NSContents">Amend</string>
-															<reference key="NSSupport" ref="554612341"/>
-															<reference key="NSControlView" ref="18874447"/>
-															<int key="NSButtonFlags">1211912448</int>
-															<int key="NSButtonFlags2">402653186</int>
-															<object class="NSCustomResource" key="NSNormalImage">
-																<string key="NSClassName">NSImage</string>
-																<string key="NSResourceName">NSSwitch</string>
+														<reference key="NSNextKeyView" ref="833001498"/>
+														<string key="NSReuseIdentifierKey">_NS:9</string>
+														<array class="NSMutableArray" key="NSTabViewItems">
+															<object class="NSTabViewItem" id="394750177">
+																<string key="NSIdentifier">1</string>
+																<object class="NSView" key="NSView" id="566981842">
+																	<nil key="NSNextResponder"/>
+																	<int key="NSvFlags">256</int>
+																	<array class="NSMutableArray" key="NSSubviews">
+																		<object class="NSButton" id="18874447">
+																			<reference key="NSNextResponder" ref="566981842"/>
+																			<int key="NSvFlags">292</int>
+																			<string key="NSFrame">{{-2, 6}, {82, 18}}</string>
+																			<reference key="NSSuperview" ref="566981842"/>
+																			<reference key="NSNextKeyView" ref="1042222292"/>
+																			<bool key="NSEnabled">YES</bool>
+																			<object class="NSButtonCell" key="NSCell" id="475684116">
+																				<int key="NSCellFlags">-2080374784</int>
+																				<int key="NSCellFlags2">0</int>
+																				<string key="NSContents">Amend</string>
+																				<object class="NSFont" key="NSSupport" id="554612341">
+																					<string key="NSName">LucidaGrande</string>
+																					<double key="NSSize">13</double>
+																					<int key="NSfFlags">1044</int>
+																				</object>
+																				<reference key="NSControlView" ref="18874447"/>
+																				<int key="NSButtonFlags">1211912448</int>
+																				<int key="NSButtonFlags2">402653186</int>
+																				<object class="NSCustomResource" key="NSNormalImage" id="994231093">
+																					<string key="NSClassName">NSImage</string>
+																					<string key="NSResourceName">NSSwitch</string>
+																				</object>
+																				<object class="NSButtonImageSource" key="NSAlternateImage" id="742762078">
+																					<string key="NSImageName">NSSwitch</string>
+																				</object>
+																				<string key="NSAlternateContents"/>
+																				<string key="NSKeyEquivalent">a</string>
+																				<int key="NSPeriodicDelay">200</int>
+																				<int key="NSPeriodicInterval">25</int>
+																			</object>
+																			<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+																		</object>
+																		<object class="NSButton" id="1042222292">
+																			<reference key="NSNextResponder" ref="566981842"/>
+																			<int key="NSvFlags">289</int>
+																			<string key="NSFrame">{{243, -2}, {96, 32}}</string>
+																			<reference key="NSSuperview" ref="566981842"/>
+																			<reference key="NSNextKeyView" ref="792511503"/>
+																			<bool key="NSEnabled">YES</bool>
+																			<object class="NSButtonCell" key="NSCell" id="964972443">
+																				<int key="NSCellFlags">67108864</int>
+																				<int key="NSCellFlags2">134217728</int>
+																				<string key="NSContents">Sign-Off</string>
+																				<reference key="NSSupport" ref="554612341"/>
+																				<reference key="NSControlView" ref="1042222292"/>
+																				<int key="NSButtonFlags">-2038284288</int>
+																				<int key="NSButtonFlags2">129</int>
+																				<string key="NSAlternateContents"/>
+																				<string key="NSKeyEquivalent"/>
+																				<int key="NSPeriodicDelay">200</int>
+																				<int key="NSPeriodicInterval">25</int>
+																			</object>
+																			<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+																		</object>
+																		<object class="NSButton" id="792511503">
+																			<reference key="NSNextResponder" ref="566981842"/>
+																			<int key="NSvFlags">289</int>
+																			<string key="NSFrame">{{339, -2}, {96, 32}}</string>
+																			<reference key="NSSuperview" ref="566981842"/>
+																			<reference key="NSNextKeyView" ref="955377287"/>
+																			<bool key="NSEnabled">YES</bool>
+																			<object class="NSButtonCell" key="NSCell" id="767461980">
+																				<int key="NSCellFlags">67108864</int>
+																				<int key="NSCellFlags2">134217728</int>
+																				<string key="NSContents">Commit</string>
+																				<reference key="NSSupport" ref="554612341"/>
+																				<reference key="NSControlView" ref="792511503"/>
+																				<int key="NSButtonFlags">-2038284288</int>
+																				<int key="NSButtonFlags2">268435585</int>
+																				<string key="NSAlternateContents"/>
+																				<string type="base64-UTF8" key="NSKeyEquivalent">DQ</string>
+																				<int key="NSPeriodicDelay">200</int>
+																				<int key="NSPeriodicInterval">25</int>
+																			</object>
+																			<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+																		</object>
+																	</array>
+																	<string key="NSFrameSize">{429, 30}</string>
+																	<reference key="NSNextKeyView" ref="18874447"/>
+																	<string key="NSReuseIdentifierKey">_NS:11</string>
+																</object>
+																<string key="NSLabel">Commit</string>
+																<object class="NSColor" key="NSColor" id="873602351">
+																	<int key="NSColorSpace">6</int>
+																	<string key="NSCatalogName">System</string>
+																	<string key="NSColorName">controlColor</string>
+																	<reference key="NSColor" ref="500580906"/>
+																</object>
+																<reference key="NSTabView" ref="312803625"/>
 															</object>
-															<object class="NSButtonImageSource" key="NSAlternateImage">
-																<string key="NSImageName">NSSwitch</string>
+															<object class="NSTabViewItem" id="909012364">
+																<string key="NSIdentifier">2</string>
+																<object class="NSView" key="NSView" id="833001498">
+																	<reference key="NSNextResponder" ref="312803625"/>
+																	<int key="NSvFlags">256</int>
+																	<array class="NSMutableArray" key="NSSubviews">
+																		<object class="NSButton" id="897820076">
+																			<reference key="NSNextResponder" ref="833001498"/>
+																			<int key="NSvFlags">265</int>
+																			<string key="NSFrame">{{302, -2}, {133, 32}}</string>
+																			<reference key="NSSuperview" ref="833001498"/>
+																			<reference key="NSWindow"/>
+																			<reference key="NSNextKeyView" ref="955377287"/>
+																			<string key="NSReuseIdentifierKey">_NS:9</string>
+																			<bool key="NSEnabled">YES</bool>
+																			<object class="NSButtonCell" key="NSCell" id="123998821">
+																				<int key="NSCellFlags">67108864</int>
+																				<int key="NSCellFlags2">134217728</int>
+																				<string key="NSContents">Stash Changes</string>
+																				<reference key="NSSupport" ref="554612341"/>
+																				<string key="NSCellIdentifier">_NS:9</string>
+																				<reference key="NSControlView" ref="897820076"/>
+																				<int key="NSButtonFlags">-2038284288</int>
+																				<int key="NSButtonFlags2">129</int>
+																				<string key="NSAlternateContents"/>
+																				<string key="NSKeyEquivalent"/>
+																				<int key="NSPeriodicDelay">200</int>
+																				<int key="NSPeriodicInterval">25</int>
+																			</object>
+																			<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+																		</object>
+																		<object class="NSButton" id="666720171">
+																			<reference key="NSNextResponder" ref="833001498"/>
+																			<int key="NSvFlags">268</int>
+																			<string key="NSFrame">{{-2, 6}, {93, 18}}</string>
+																			<reference key="NSSuperview" ref="833001498"/>
+																			<reference key="NSWindow"/>
+																			<reference key="NSNextKeyView" ref="897820076"/>
+																			<string key="NSReuseIdentifierKey">_NS:9</string>
+																			<bool key="NSEnabled">YES</bool>
+																			<object class="NSButtonCell" key="NSCell" id="1070556424">
+																				<int key="NSCellFlags">-2080374784</int>
+																				<int key="NSCellFlags2">268435456</int>
+																				<string key="NSContents">Keep Index</string>
+																				<reference key="NSSupport" ref="554612341"/>
+																				<string key="NSCellIdentifier">_NS:9</string>
+																				<reference key="NSControlView" ref="666720171"/>
+																				<int key="NSButtonFlags">1211912448</int>
+																				<int key="NSButtonFlags2">2</int>
+																				<reference key="NSNormalImage" ref="994231093"/>
+																				<reference key="NSAlternateImage" ref="742762078"/>
+																				<string key="NSAlternateContents"/>
+																				<string key="NSKeyEquivalent"/>
+																				<int key="NSPeriodicDelay">200</int>
+																				<int key="NSPeriodicInterval">25</int>
+																			</object>
+																			<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+																		</object>
+																	</array>
+																	<string key="NSFrameSize">{429, 30}</string>
+																	<reference key="NSSuperview" ref="312803625"/>
+																	<reference key="NSWindow"/>
+																	<reference key="NSNextKeyView" ref="666720171"/>
+																	<string key="NSReuseIdentifierKey">_NS:28</string>
+																</object>
+																<string key="NSLabel">Stash</string>
+																<reference key="NSColor" ref="873602351"/>
+																<reference key="NSTabView" ref="312803625"/>
 															</object>
-															<string key="NSAlternateContents"/>
-															<string key="NSKeyEquivalent">a</string>
-															<int key="NSPeriodicDelay">200</int>
-															<int key="NSPeriodicInterval">25</int>
+														</array>
+														<reference key="NSSelectedTabViewItem" ref="909012364"/>
+														<object class="NSFont" key="NSFont">
+															<string key="NSName">LucidaGrande</string>
+															<double key="NSSize">9</double>
+															<int key="NSfFlags">3614</int>
 														</object>
-														<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-													</object>
-													<object class="NSButton" id="1042222292">
-														<reference key="NSNextResponder" ref="154221104"/>
-														<int key="NSvFlags">289</int>
-														<string key="NSFrame">{{243, 0}, {96, 32}}</string>
-														<reference key="NSSuperview" ref="154221104"/>
-														<reference key="NSWindow"/>
-														<reference key="NSNextKeyView" ref="792511503"/>
-														<bool key="NSEnabled">YES</bool>
-														<object class="NSButtonCell" key="NSCell" id="964972443">
-															<int key="NSCellFlags">67108864</int>
-															<int key="NSCellFlags2">134217728</int>
-															<string key="NSContents">Sign-Off</string>
-															<reference key="NSSupport" ref="554612341"/>
-															<reference key="NSControlView" ref="1042222292"/>
-															<int key="NSButtonFlags">-2038284288</int>
-															<int key="NSButtonFlags2">129</int>
-															<string key="NSAlternateContents"/>
-															<string key="NSKeyEquivalent"/>
-															<int key="NSPeriodicDelay">200</int>
-															<int key="NSPeriodicInterval">25</int>
-														</object>
-														<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+														<int key="NSTvFlags">268435462</int>
+														<bool key="NSAllowTruncatedLabels">YES</bool>
+														<array class="NSMutableArray" key="NSSubviews">
+															<reference ref="833001498"/>
+														</array>
 													</object>
 												</array>
 												<string key="NSFrameSize">{429, 227}</string>
@@ -795,14 +906,6 @@
 					<int key="connectionID">156</int>
 				</object>
 				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">commit:</string>
-						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="792511503"/>
-					</object>
-					<int key="connectionID">212</int>
-				</object>
-				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
 						<string key="label">commitMessageView</string>
 						<reference key="source" ref="1001"/>
@@ -827,12 +930,12 @@
 					<int key="connectionID">256</int>
 				</object>
 				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">signOff:</string>
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">commitSplitView</string>
 						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="1042222292"/>
+						<reference key="destination" ref="812432808"/>
 					</object>
-					<int key="connectionID">280</int>
+					<int key="connectionID">314</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
@@ -843,12 +946,36 @@
 					<int key="connectionID">307</int>
 				</object>
 				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">commitSplitView</string>
+					<object class="IBActionConnection" key="connection">
+						<string key="label">commit:</string>
 						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="812432808"/>
+						<reference key="destination" ref="792511503"/>
 					</object>
-					<int key="connectionID">314</int>
+					<int key="connectionID">212</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">signOff:</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="1042222292"/>
+					</object>
+					<int key="connectionID">280</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">controlsTabView</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="312803625"/>
+					</object>
+					<int key="connectionID">324</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">stashChanges:</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="897820076"/>
+					</object>
+					<int key="connectionID">325</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
@@ -1074,6 +1201,22 @@
 					</object>
 					<int key="connectionID">269</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">value: self.stashKeepIndex</string>
+						<reference key="source" ref="666720171"/>
+						<reference key="destination" ref="1001"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="666720171"/>
+							<reference key="NSDestination" ref="1001"/>
+							<string key="NSLabel">value: self.stashKeepIndex</string>
+							<string key="NSBinding">value</string>
+							<string key="NSKeyPath">self.stashKeepIndex</string>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">333</int>
+				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<array key="orderedObjects">
@@ -1169,9 +1312,7 @@
 						<reference key="object" ref="635871052"/>
 						<array class="NSMutableArray" key="children">
 							<reference ref="227052526"/>
-							<reference ref="792511503"/>
-							<reference ref="18874447"/>
-							<reference ref="1042222292"/>
+							<reference ref="312803625"/>
 						</array>
 						<reference key="parent" ref="217294340"/>
 					</object>
@@ -1225,14 +1366,6 @@
 						<reference key="parent" ref="746911078"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">163</int>
-						<reference key="object" ref="792511503"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="767461980"/>
-						</array>
-						<reference key="parent" ref="635871052"/>
-					</object>
-					<object class="IBObjectRecord">
 						<int key="objectID">130</int>
 						<reference key="object" ref="227052526"/>
 						<array class="NSMutableArray" key="children">
@@ -1256,11 +1389,6 @@
 						<int key="objectID">131</int>
 						<reference key="object" ref="20200144"/>
 						<reference key="parent" ref="227052526"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">164</int>
-						<reference key="object" ref="767461980"/>
-						<reference key="parent" ref="792511503"/>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">54</int>
@@ -1304,12 +1432,61 @@
 						<reference key="parent" ref="79177434"/>
 					</object>
 					<object class="IBObjectRecord">
+						<int key="objectID">254</int>
+						<reference key="object" ref="446885874"/>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">315</int>
+						<reference key="object" ref="312803625"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="394750177"/>
+							<reference ref="909012364"/>
+						</array>
+						<reference key="parent" ref="635871052"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">316</int>
+						<reference key="object" ref="394750177"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="566981842"/>
+						</array>
+						<reference key="parent" ref="312803625"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">317</int>
+						<reference key="object" ref="909012364"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="833001498"/>
+						</array>
+						<reference key="parent" ref="312803625"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">318</int>
+						<reference key="object" ref="833001498"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="897820076"/>
+							<reference ref="666720171"/>
+						</array>
+						<reference key="parent" ref="909012364"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">319</int>
+						<reference key="object" ref="566981842"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="792511503"/>
+							<reference ref="1042222292"/>
+							<reference ref="18874447"/>
+						</array>
+						<reference key="parent" ref="394750177"/>
+					</object>
+					<object class="IBObjectRecord">
 						<int key="objectID">247</int>
 						<reference key="object" ref="18874447"/>
 						<array class="NSMutableArray" key="children">
 							<reference ref="475684116"/>
 						</array>
-						<reference key="parent" ref="635871052"/>
+						<reference key="parent" ref="566981842"/>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">248</int>
@@ -1317,9 +1494,17 @@
 						<reference key="parent" ref="18874447"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">254</int>
-						<reference key="object" ref="446885874"/>
-						<reference key="parent" ref="0"/>
+						<int key="objectID">163</int>
+						<reference key="object" ref="792511503"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="767461980"/>
+						</array>
+						<reference key="parent" ref="566981842"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">164</int>
+						<reference key="object" ref="767461980"/>
+						<reference key="parent" ref="792511503"/>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">278</int>
@@ -1327,12 +1512,38 @@
 						<array class="NSMutableArray" key="children">
 							<reference ref="964972443"/>
 						</array>
-						<reference key="parent" ref="635871052"/>
+						<reference key="parent" ref="566981842"/>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">279</int>
 						<reference key="object" ref="964972443"/>
 						<reference key="parent" ref="1042222292"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">320</int>
+						<reference key="object" ref="897820076"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="123998821"/>
+						</array>
+						<reference key="parent" ref="833001498"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">321</int>
+						<reference key="object" ref="123998821"/>
+						<reference key="parent" ref="897820076"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">322</int>
+						<reference key="object" ref="666720171"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="1070556424"/>
+						</array>
+						<reference key="parent" ref="833001498"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">323</int>
+						<reference key="object" ref="1070556424"/>
+						<reference key="parent" ref="666720171"/>
 					</object>
 				</array>
 			</object>
@@ -1366,6 +1577,23 @@
 				<string key="254.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="278.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="279.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<object class="NSMutableDictionary" key="315.IBAttributePlaceholdersKey">
+					<string key="NS.key.0">InitialTabViewItem</string>
+					<object class="IBInitialTabViewItemAttribute" key="NS.object.0">
+						<string key="name">InitialTabViewItem</string>
+						<reference key="object" ref="312803625"/>
+						<reference key="initialTabViewItem" ref="394750177"/>
+					</object>
+				</object>
+				<string key="315.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="316.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="317.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="318.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="319.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="320.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="321.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="322.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="323.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="45.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="46.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="47.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -1385,7 +1613,7 @@
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">314</int>
+			<int key="maxID">333</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -1413,6 +1641,7 @@
 						<string key="forceCommit:">id</string>
 						<string key="refresh:">id</string>
 						<string key="signOff:">id</string>
+						<string key="stashChanges:">id</string>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="actionInfosByName">
 						<object class="IBActionInfo" key="commit:">
@@ -1431,12 +1660,17 @@
 							<string key="name">signOff:</string>
 							<string key="candidateClassName">id</string>
 						</object>
+						<object class="IBActionInfo" key="stashChanges:">
+							<string key="name">stashChanges:</string>
+							<string key="candidateClassName">id</string>
+						</object>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="outlets">
 						<string key="cachedFilesController">NSArrayController</string>
 						<string key="commitButton">NSButton</string>
 						<string key="commitMessageView">NSTextView</string>
 						<string key="commitSplitView">PBNiceSplitView</string>
+						<string key="controlsTabView">NSTabView</string>
 						<string key="indexController">PBGitIndexController</string>
 						<string key="unstagedFilesController">NSArrayController</string>
 						<string key="webController">PBWebChangesController</string>
@@ -1457,6 +1691,10 @@
 						<object class="IBToOneOutletInfo" key="commitSplitView">
 							<string key="name">commitSplitView</string>
 							<string key="candidateClassName">PBNiceSplitView</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="controlsTabView">
+							<string key="name">controlsTabView</string>
+							<string key="candidateClassName">NSTabView</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="indexController">
 							<string key="name">indexController</string>
@@ -1614,24 +1852,6 @@
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
 						<string key="minorKey">./Classes/PBWebController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">WebView</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">reloadFromOrigin:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">reloadFromOrigin:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">reloadFromOrigin:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/WebView.h</string>
 					</object>
 				</object>
 			</array>

--- a/Resources/XIBs/PBGitCommitView.xib
+++ b/Resources/XIBs/PBGitCommitView.xib
@@ -872,6 +872,15 @@
 				<bool key="NSFilterRestrictsInsertion">YES</bool>
 				<bool key="NSAutomaticallyRearrangesObjects">YES</bool>
 			</object>
+			<object class="NSArrayController" id="803565714">
+				<bool key="NSEditable">YES</bool>
+				<object class="_NSManagedProxy" key="_NSManagedProxy"/>
+				<bool key="NSAvoidsEmptySelection">YES</bool>
+				<bool key="NSPreservesSelection">YES</bool>
+				<bool key="NSSelectsInsertedObjects">YES</bool>
+				<bool key="NSFilterRestrictsInsertion">YES</bool>
+				<bool key="NSClearsFilterPredicateOnInsertion">YES</bool>
+			</object>
 			<object class="NSCustomObject" id="1007648253">
 				<string key="NSClassName">PBWebChangesController</string>
 			</object>
@@ -976,6 +985,22 @@
 						<reference key="destination" ref="897820076"/>
 					</object>
 					<int key="connectionID">325</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">trackedFilesController</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="803565714"/>
+					</object>
+					<int key="connectionID">341</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">stashButton</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="897820076"/>
+					</object>
+					<int key="connectionID">342</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
@@ -1216,6 +1241,22 @@
 						</object>
 					</object>
 					<int key="connectionID">333</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">contentArray: index.indexChanges</string>
+						<reference key="source" ref="803565714"/>
+						<reference key="destination" ref="1001"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="803565714"/>
+							<reference key="NSDestination" ref="1001"/>
+							<string key="NSLabel">contentArray: index.indexChanges</string>
+							<string key="NSBinding">contentArray</string>
+							<string key="NSKeyPath">index.indexChanges</string>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">340</int>
 				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -1545,6 +1586,12 @@
 						<reference key="object" ref="1070556424"/>
 						<reference key="parent" ref="666720171"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">335</int>
+						<reference key="object" ref="803565714"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">Tracked Files</string>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -1594,6 +1641,7 @@
 				<string key="321.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="322.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="323.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="335.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="45.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="46.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="47.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -1613,7 +1661,7 @@
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">333</int>
+			<int key="maxID">342</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -1672,6 +1720,8 @@
 						<string key="commitSplitView">PBNiceSplitView</string>
 						<string key="controlsTabView">NSTabView</string>
 						<string key="indexController">PBGitIndexController</string>
+						<string key="stashButton">NSButton</string>
+						<string key="trackedFilesController">NSArrayController</string>
 						<string key="unstagedFilesController">NSArrayController</string>
 						<string key="webController">PBWebChangesController</string>
 					</dictionary>
@@ -1699,6 +1749,14 @@
 						<object class="IBToOneOutletInfo" key="indexController">
 							<string key="name">indexController</string>
 							<string key="candidateClassName">PBGitIndexController</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="stashButton">
+							<string key="name">stashButton</string>
+							<string key="candidateClassName">NSButton</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="trackedFilesController">
+							<string key="name">trackedFilesController</string>
+							<string key="candidateClassName">NSArrayController</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="unstagedFilesController">
 							<string key="name">unstagedFilesController</string>


### PR DESCRIPTION
Support for stashes (see #14 )

Major Tasks:
- [x] list stashes in sidebar (with libgit2)
- [x] pop stash (context menu)
- [x] apply stash (context menu)
- [x] drop stash (context menu)
- [x] view diff (context menu, open in new window)
- [x] stash save via commit dialog (Hold down ⌥-key in commit dialog to reveal 'Stash Changes' button and 'Keep Index' checkbox.)
- [x] app menu items:
  - "Stash Save ⌘Y"
  - "Stash Save - Keep Index ⌥⌘Y" (alternate)
  - "Stash Pop ⇧⌘Y"
- [x] display an error message when "stash save/pop/apply" result in error

Optional Todos:
- [ ] implement "stash save/pop/apply" via objective-git or libgit2

---

![gitx](https://f.cloud.github.com/assets/26716/927199/974bf55c-ff9b-11e2-99a2-16c959645016.png)

![gitx branch_ gitx-dev-stashes](https://f.cloud.github.com/assets/26716/927212/e53c0482-ff9b-11e2-9851-d53bdbe0c602.png)
