### PR TITLE
add objective-git, Sparkle and MGScopeBar to Framework Search Path

### DIFF
--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -1771,7 +1771,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$(PROJECT_DIR)\"";
+				FRAMEWORK_SEARCH_PATHS = (
+					"\"$(PROJECT_DIR)\"",
+					"\"$(SRCROOT)/objective-git/build/Debug\"",
+					"\"$(SRCROOT)/Sparkle/build/Debug\"",
+					"\"$(SRCROOT)/MGScopeBar/build/Debug\"",
+				);
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -1790,7 +1795,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$(PROJECT_DIR)\"";
+				FRAMEWORK_SEARCH_PATHS = (
+					"\"$(PROJECT_DIR)\"",
+					"\"$(SRCROOT)/objective-git/build/Release\"",
+					"\"$(SRCROOT)/Sparkle/build/Release\"",
+					"\"$(SRCROOT)/MGScopeBar/build/Release\"",
+				);
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = GitX_Prefix.pch;
@@ -1874,6 +1884,12 @@
 		913D5E4B0E55644600CECEA2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/objective-git/build/Debug\"",
+					"\"$(SRCROOT)/Sparkle/build/Debug\"",
+					"\"$(SRCROOT)/MGScopeBar/build/Debug\"",
+				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = GitX_Prefix.pch;
 				INSTALL_PATH = /usr/local/bin;
@@ -1884,6 +1900,12 @@
 		913D5E4C0E55644600CECEA2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/objective-git/build/Release\"",
+					"\"$(SRCROOT)/Sparkle/build/Release\"",
+					"\"$(SRCROOT)/MGScopeBar/build/Release\"",
+				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = GitX_Prefix.pch;
 				INSTALL_PATH = /usr/local/bin;


### PR DESCRIPTION
Without adding the frameworks to the search path, building fails in Xcode 4.6,
because the headers from those frameworks won't be found. Adding them manually
fixes this problem.
