### PR TITLE
Gitx dev diff word highlight

### DIFF
--- a/html/css/diff.css
+++ b/html/css/diff.css
@@ -50,6 +50,12 @@
 .diff .file .diffcontent .lines .whitespace {
 	background-color: rgba(255,0,0,0.5);
 }
+.diff .file .diffcontent .lines del,
+.diff .file .diffcontent .lines ins { text-decoration: none; }
+.diff .file .diffcontent .lines .delline { background: #fdd }
+.diff .file .diffcontent .lines .delline del { background: #ffaaaa; }
+.diff .file .diffcontent .lines .addline { background: #dfd }
+.diff .file .diffcontent .lines .addline ins { background: #aaffaa; }
 
 #CurrentHunk {
 	border-left: 5px solid black;

--- a/html/css/diff.css
+++ b/html/css/diff.css
@@ -51,11 +51,15 @@
 	background-color: rgba(255,0,0,0.5);
 }
 .diff .file .diffcontent .lines del,
-.diff .file .diffcontent .lines ins { text-decoration: none; }
-.diff .file .diffcontent .lines .delline { background: #fdd }
-.diff .file .diffcontent .lines .delline del { background: #ffaaaa; }
-.diff .file .diffcontent .lines .addline { background: #dfd }
-.diff .file .diffcontent .lines .addline ins { background: #aaffaa; }
+.diff .file .diffcontent .lines ins {
+	text-decoration: none;
+}
+.diff .file .diffcontent .lines .delline del {
+	background-color: #e8ced1;
+}
+.diff .file .diffcontent .lines .addline ins {
+	background-color: #c2ecbf;
+}
 
 #CurrentHunk {
 	border-left: 5px solid black;

--- a/html/css/diff.css
+++ b/html/css/diff.css
@@ -52,13 +52,15 @@
 }
 .diff .file .diffcontent .lines del,
 .diff .file .diffcontent .lines ins {
-	text-decoration: none;
+	text-decoration: none; border-radius: 0.3em;
 }
 .diff .file .diffcontent .lines .delline del {
-	background-color: #e8ced1;
+	background-color: #febfbf;
+	color: #A00;
 }
 .diff .file .diffcontent .lines .addline ins {
-	background-color: #c2ecbf;
+	background-color: #b2ffaf;
+	color: #070;
 }
 
 #CurrentHunk {

--- a/html/inlinedifftest.html
+++ b/html/inlinedifftest.html
@@ -1,0 +1,107 @@
+<html>
+    <head>
+        
+        <link rel="stylesheet" href="css/GitX.css" type="text/css" media="screen" title="no title" charset="utf-8">
+        <link rel="stylesheet" href="css/diff.css" type="text/css" media="screen" title="no title" charset="utf-8">
+        <script src="lib/jquery-2.0.2.min.js" type="text/javascript" charset="utf-8"></script>
+        <script src="lib/GitX.js" type="text/javascript" charset="utf-8"></script>
+        <script src="lib/diffHighlighter.js" type="text/javascript" charset="utf-8"></script>
+    </head>
+    <body>
+        <div id="results"></div>
+        <textarea id="test-data">
+-the red fox jumped into the leaf
++the brown fox dashed into the leaf
+---------------------------------------
+-foo bar baz barf
++foo baz bar barf
+---------------------------------------
+-       return {bounds:[from,to],good:good};
++       var ret =  {bounds:[from,to],good:good};
++       Controller.log_("computeSelection: from: "+from.outerHTML);
++       Controller.log_("computeSelection: {bounds:["+from+","+to+"],good: "+good+" }");
++       return ret;
+---------------------------------------
+-whitespace
++whitespace   
+---------------------------------------
+-	tab indent to spaces
++        tab indent to spaces
+---------------------------------------
+-   NSString* installationPath = @"/usr/local/bin/gitx";
++   NSString* installationPath = @"/usr/local/bin/";
++   NSString* installationName = @"gitx";
+---------------------------------------
+-           char const* arguments[] = { "-f", "-s", [toolPath UTF8String], [installationPath UTF8String], NULL };
++           char const* mkdir_arg[] = { "-p", [installationPath UTF8String], NULL};       
++           char const* mkdir   = "/bin/mkdir";
++           AuthorizationExecuteWithPrivileges(auth, mkdir, kAuthorizationFlagDefaults, (char**)mkdir_arg, NULL);
++           char const* arguments[] = { "-f", "-s", [toolPath UTF8String], [[installationPath stringByAppendingString: installationName] UTF8String],  NULL };
+</textarea>
+<script type="text/javascript" charset="utf-8">
+
+jQuery(function($){
+    update();
+    return;
+    
+    function getData() {
+        return $('#test-data').val();
+    }
+
+    function parseData(rawData) {
+        var blocks = rawData.split(/\n?-{10,}\n?/);
+        return $.map(blocks, function(block) {
+            var l = block.split(/\n/),
+                o = [], n = [];
+            for (var i = 0; i < l.length; i++) {
+                (l[i][0] == "-" ? o : n).push(l[i].substring(1));
+            }
+            return [[o.join("\n"), n.join("\n")]];
+        });
+    }
+
+    function update() {
+        var testData = parseData(getData());
+        $('#results').text('');
+        for (var i = 0; i < testData.length; i++) {
+            var o = testData[i][0], n = testData[i][1];
+            $('#results').append(resultForTestData(o, n));
+        };
+    }
+
+    function stripTags(h) {
+        return h.replace(/<\/?\w+\/?>/g,'');
+    }
+
+    function resultForTestData(o,n) {
+        var diff = inlinediff.diffString3(o,n);
+        var eo = inlinediff.escape(o);
+        var en = inlinediff.escape(n);
+        var oldOk = eo == stripTags(diff[1]);
+        var newOk = en == stripTags(diff[2]);
+        var ok = oldOk && newOk;
+        return $("<div/>")
+            .addClass("test")
+            .addClass(ok ? "ok" : "fail")
+            .append([oldOk, newOk].join(", "))
+            //.append($("<pre/>").addClass("comb").html(diff[0]))
+            .append($("<pre/>").addClass("old").html(diff[1]))
+            .append($("<pre/>").addClass("new").html(diff[2]));
+    }
+});
+
+</script>
+<style type="text/css">
+    .test {
+        margin: 1em; border: 1px solid #eee; padding: 0.5em; border-radius: 0.5em;
+    }
+    .test.fail {border: 2px solid #a60004;}
+    .test pre { margin:0 }
+    .test .old { background: #feccce}
+    .test .new { background: #c4ffc1}
+    .test ins, .test del { background-color: rgba(0,0,0,0.15); text-decoration: none; border-radius: 0.25em;}
+    .test .comb del { background-color: rgba(255,0,0,0.15); text-decoration: line-through; }
+    .test .comb ins { background-color: rgba(0,255,0,0.15); }
+</style>
+    </body>
+</html>

--- a/html/inlinedifftest.html
+++ b/html/inlinedifftest.html
@@ -28,6 +28,22 @@
 -	tab indent to spaces
 +        tab indent to spaces
 ---------------------------------------
+-   a = "hello";
+-   b = "world";
+-   c = a + " " + b;
++   if (true) {
++     a = "hello";
++     b = "world";
++     c = a + " " + b;
++   }
+---------------------------------------
+-      n = n.replace(/&lt;/g, "&amp;lt;");
+-      n = n.replace(/&gt;/g, "&amp;gt;");
++      if (true) {
++        n = n.replace(/&lt;/g, "&amp;lt;");
++        n = n.replace(/&gt;/g, "&amp;gt;");
++      }
+---------------------------------------
 -   NSString* installationPath = @"/usr/local/bin/gitx";
 +   NSString* installationPath = @"/usr/local/bin/";
 +   NSString* installationName = @"gitx";

--- a/html/lib/diffHighlighter.js
+++ b/html/lib/diffHighlighter.js
@@ -278,9 +278,11 @@ var postProcessDiffContents = function(diffContent) {
 				// hunk only contains additions OR deletions, so there is no need
 				// to do any inline-diff. just keep the elements as they are
 				buffer = $.map(oldEls.length ? oldEls : newEls, function (e) {
-					if (newEls.length) {
-						e.html(highlightTrailingWhitespace(e.html()));
-					}
+					var prefix = e.text().substring(0,1),
+						text = e.text().substring(1),
+						tag = prefix=='+' ? 'ins' : 'del',
+						html = prefix+'<'+tag+'>'+(prefix == "+" ? highlightTrailingWhitespace(text) : text)+'</'+tag+'>';
+					e.html(html);
 					return dumbEl.html(e).html();
 				}).join("");
 			}

--- a/html/lib/diffHighlighter.js
+++ b/html/lib/diffHighlighter.js
@@ -407,22 +407,7 @@ var inlinediff = (function () {
   }
 
   function whitespaceAwareTokenize(n) {
-    var nz = [], nn = n === "" ? [] : (n.match(/\n|[^\n]+/g) || []);
-    for (var i = 0; i < nn.length; i++) {
-        if (nn[i] == "\n") {
-            nz.push(nn[i]);
-        }
-        else {
-            var ns = (nn[i].match(/\s+|[^\s]+/g) || []);
-            for (var k = 0; k < ns.length; k++) {
-                var nw = (ns[k].match(/\s+|\W|\w+/g) || []);
-                for (var j = 0; j < nw.length; j++) {
-                    nz.push(nw[j]);
-                }
-            }
-        }
-    }
-    return nz;
+    return n !== "" && n.match(/\n| *[\-><!=]+ *|[ \t]+|[<$&#§%]\w+|\w+|\W/g) || [];
   }
 
   function tag(t,c) {

--- a/html/lib/diffHighlighter.js
+++ b/html/lib/diffHighlighter.js
@@ -279,7 +279,7 @@ var postProcessDiffContents = function(diffContent) {
 				// to do any inline-diff. just keep the elements as they are
 				buffer = $.map(oldEls.length ? oldEls : newEls, function (e) {
 					var prefix = e.text().substring(0,1),
-						text = e.text().substring(1),
+						text = inlinediff.escape(e.text().substring(1)),
 						tag = prefix=='+' ? 'ins' : 'del',
 						html = prefix+'<'+tag+'>'+(prefix == "+" ? highlightTrailingWhitespace(text) : text)+'</'+tag+'>';
 					e.html(html);

--- a/html/lib/diffHighlighter.js
+++ b/html/lib/diffHighlighter.js
@@ -40,7 +40,7 @@ var highlightDiff = function(diff, element, callbacks) {
 		callbacks = {};
 	var start = new Date().getTime();
 	element.className = "diff"
-	var content = diff.escapeHTML().replace(/\t/g, "    ");;
+	var content = diff.escapeHTML();
 
 	var file_index = 0;
 
@@ -102,7 +102,7 @@ var highlightDiff = function(diff, element, callbacks) {
 			finalContent +=		'<div id="content_' + title + '" class="diffContent">' +
 								'<div class="lineno">' + line1 + "</div>" +
 								'<div class="lineno">' + line2 + "</div>" +
-								'<div class="lines">' + postProcessDiffContents(diffContent) + "</div>" +
+								'<div class="lines">' + postProcessDiffContents(diffContent).replace(/\t/g, "    ") + "</div>" +
 							'</div>';
 		}
 		else {

--- a/html/lib/diffHighlighter.js
+++ b/html/lib/diffHighlighter.js
@@ -289,8 +289,9 @@ var postProcessDiffContents = function(diffContent) {
 			else {
 				// hunk contains additions AND deletions. so we create an inline diff
 				// of all the old and new lines together and merge the result back to buffer
-				var oldText = $.map(oldEls, function (e) { return e.text().substring(1); }).join("\n");
-				var newText = $.map(newEls, function (e) { return e.text().substring(1); }).join("\n");
+				var mapFn = function (e) { return e.text().substring(1).replace(/\r?\n|\r/g,''); };
+				var oldText = $.map(oldEls, mapFn).join("\n");
+				var newText = $.map(newEls, mapFn).join("\n");
 				var diffResult = inlinediff.diffString3(oldText,newText);
 					diffLines = (diffResult[1] + "\n" + diffResult[2]).split(/\n/g);
 				

--- a/html/lib/diffHighlighter.js
+++ b/html/lib/diffHighlighter.js
@@ -407,10 +407,22 @@ var inlinediff = (function () {
   }
 
   function whitespaceAwareTokenize(n) {
-  	var nt = n == "" ? [] : n.split(/[ \t]+|\n/);
-    var nw = n == "" ? [] : (n.match(/[ \t]+|\n/g) || []);
-    var nz = []; for (var i=0; i < nt.length; i++) { nz.push(nt[i]); if (i < nw.length) nz.push(nw[i]); };
-  	return nz;
+    var nz = [], nn = n === "" ? [] : (n.match(/\n|[^\n]+/g) || []);
+    for (var i = 0; i < nn.length; i++) {
+        if (nn[i] == "\n") {
+            nz.push(nn[i]);
+        }
+        else {
+            var ns = (nn[i].match(/\s+|[^\s]+/g) || []);
+            for (var k = 0; k < ns.length; k++) {
+                var nw = (ns[k].match(/\s+|\W|\w+/g) || []);
+                for (var j = 0; j < nw.length; j++) {
+                    nz.push(nw[j]);
+                }
+            }
+        }
+    }
+    return nz;
   }
 
   function tag(t,c) {

--- a/html/views/commit/commit.css
+++ b/html/views/commit/commit.css
@@ -87,6 +87,13 @@ table.diff {
 #selected div {
     background-color: #B5D5FE;
 }
+#selected div del,
+#selected div ins {
+    background-color: #9abbea;
+}
+#selected div .whitespace {
+    background-color: #7795c7;
+}
 
 #selected #stagelines {
     padding-left: 2px;

--- a/html/views/commit/commit.js
+++ b/html/views/commit/commit.js
@@ -5,7 +5,7 @@ var contextLines = 0;
 
 var showNewFile = function(file)
 {
-	setTitle("New file: " + file.path);
+	setTitle("New file: " + file.path.escapeHTML());
 
 	var contents = Index.diffForFile_staged_contextLines_(file, false, contextLines);
 	if (!contents) {
@@ -59,7 +59,7 @@ var showFileChanges = function(file, cached) {
 	if (file.status == 0) // New file?
 		return showNewFile(file);
 
-	setTitle((cached ? "Staged": "Unstaged") + " changes for " + file.path);
+	setTitle((cached ? "Staged": "Unstaged") + " changes for " + file.path.escapeHTML());
 	displayContext();
 	var changes = Index.diffForFile_staged_contextLines_(file, cached, contextLines);
 	

--- a/html/views/commit/commit.js
+++ b/html/views/commit/commit.js
@@ -72,6 +72,15 @@ var showFileChanges = function(file, cached) {
 	displayDiff(changes, cached);
 }
 
+var findParentElementByTag = function (el, tagName)
+{
+	tagName = tagName.toUpperCase();
+	while (el && el.tagName != tagName && el.parentNode) {
+		el = el.parentNode;
+	}
+	return el;
+}
+
 /* Set the event handlers for mouse clicks/drags */
 var setSelectHandlers = function()
 {
@@ -96,10 +105,11 @@ var setSelectHandlers = function()
 	for (i = 0; i < list.length; ++i) {
 		var file = list[i];
 		file.ondblclick = function (event) {
-			var file = event.target.parentNode;
+			var target = findParentElementByTag(event.target, "div");
+			var file = target.parentNode;
 			if (file.id = "selected")
 				file = file.parentNode;
-			var start = event.target;
+			var start = target;
 			var elem_class = start.getAttribute("class");
 			if(!elem_class || !(elem_class == "addline" | elem_class == "delline")) 
 				return false;
@@ -117,7 +127,8 @@ var setSelectHandlers = function()
 			if (elem_class == "hunkheader" || elem_class == "hunkbutton")
 				return false;
 
-			var file = event.target.parentNode;
+			var target = findParentElementByTag(event.target, "div");
+			var file = target.parentNode;
 			if (file.id && file.id == "selected")
 				file = file.parentNode;
 
@@ -129,7 +140,7 @@ var setSelectHandlers = function()
 			};
 
 			if (event.shiftKey && currentSelection) { // Extend selection
-				var index = parseInt(event.target.getAttribute("index"));
+				var index = parseInt(target.getAttribute("index"));
 				var min = parseInt(currentSelection.bounds[0].getAttribute("index"));
 				var max = parseInt(currentSelection.bounds[1].getAttribute("index"));
 				var ender = 1;
@@ -139,21 +150,21 @@ var setSelectHandlers = function()
 				}
 
 				if (index < min)
-					showSelection(file,currentSelection.bounds[ender],
-						      event.target);
+					showSelection(file,currentSelection.bounds[ender],target);
 				else if (index > max)
-					showSelection(file,currentSelection.bounds[1-ender],
-						      event.target);
-				else showSelection(file,currentSelection.bounds[0],event.target);
+					showSelection(file,currentSelection.bounds[1-ender],target);
+				else
+					showSelection(file,currentSelection.bounds[0],target);
 				return false;
 			}
 
-
+			var srcElement = findParentElementByTag(event.srcElement, "div");
 			file.onmouseover = function(event2) {
-				showSelection(file, event.srcElement, event2.target);
+				var target2 = findParentElementByTag(event2.target, "div");
+				showSelection(file, srcElement, target2);
 				return false;
 			};
-			showSelection(file, event.srcElement, event.srcElement);
+			showSelection(file, srcElement, srcElement);
 			return false;
 		}
 	}
@@ -339,8 +350,9 @@ var computeSelection = function(list, from,to)
 {
 	var startIndex = parseInt(from.getAttribute("index"));
 	var endIndex = parseInt(to.getAttribute("index"));
-	if (startIndex == -1 || endIndex == -1)
+	if (startIndex == -1 || endIndex == -1) {
 		return false;
+	}
 
 	var up = (startIndex < endIndex);
 	var nextelem = up?"nextSibling":"previousSibling";

--- a/html/views/history/history.css
+++ b/html/views/history/history.css
@@ -114,6 +114,16 @@ a.servicebutton:hover {
 	margin-bottom: 0.25em;
 }
 
+#files a .renamed .meta,
+#files a .renamed .old {
+	color: #888888;
+	border-bottom: 1px solid #ffffff;
+}
+
+#files a .renamed .meta {
+	font-weight: bold;
+}
+
 .clear_both {
 	clear:both;
 	display:block;

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -209,6 +209,40 @@ var loadCommit = function(commitObject, currentRef) {
 
 }
 
+var commonPrefix = function(a, b) {
+    if (a === b) return a;
+    var i = 0;
+    while (a.charAt(i) == b.charAt(i))++i;
+    return a.substring(0, i);
+};
+var commonSuffix = function(a, b) {
+    if (a === b) return "";
+    var i = a.length - 1,
+        k = b.length - 1;
+    while (a.charAt(i) == b.charAt(k)) {
+        --i;
+        --k;
+    }
+    return a.substring(i + 1, a.length);
+};
+var renameDiff = function(a, b) {
+    var p = commonPrefix(a, b),
+        s = commonSuffix(a, b),
+        o = a.substring(p.length, a.length - s.length),
+        n = b.substring(p.length, b.length - s.length);
+    return [p, o, n, s];
+};
+var formatRenameDiff = function(d) {
+    var p = d[0],
+        o = d[1],
+        n = d[2],
+        s = d[3];
+    if (o === "" && n === "" && s === "") {
+        return p;
+    }
+    return [p, "{ ", o, " -> ", n, " }", s].join("");
+};
+
 var showDiff = function() {
 
 	$("files").innerHTML = "";
@@ -221,6 +255,7 @@ var showDiff = function() {
 		link.setAttribute("href", "#" + id);
 		p.appendChild(link);
 		var finalFile = "";
+		var renamed = false;
 		if (name1 == name2) {
 			finalFile = name1;
 			img.src = "../../images/modified.png";
@@ -242,14 +277,29 @@ var showDiff = function() {
 			finalFile = name1;
 		}
 		else {
+			renamed = true;
+		}
+		if (renamed) {
 			img.src = "../../images/renamed.png";
 			img.title = "Renamed file";
 			p.title = "Renamed file";
 			finalFile = name2;
-			p.insertBefore(document.createTextNode(name1 + " -> "), link);
+			var rfd = renameDiff(name1.unEscapeHTML(), name2.unEscapeHTML());
+			var html = [
+					'<span class="renamed">',
+					rfd[0].escapeHTML(),
+					'<span class="meta"> { </span>',
+					'<span class="old">', rfd[1].escapeHTML(), '</span>',
+					'<span class="meta"> -&gt; </span>',
+					'<span class="new">', rfd[2].escapeHTML(), '</span>',
+					'<span class="meta"> } </span>',
+					rfd[3].escapeHTML(),
+                    '</span>'
+				].join("");
+			link.innerHTML = html;
+		} else {
+			link.appendChild(document.createTextNode(finalFile.unEscapeHTML()));
 		}
-
-		link.appendChild(document.createTextNode(finalFile.unEscapeHTML()));
 		link.setAttribute("representedFile", finalFile);
 
 		p.insertBefore(img, link);


### PR DESCRIPTION
Integrated an inline word diff algorithm to highlight changed words in diffs. similar to github's hybrid mode. 
Addressing  #168

The javascript implementation is based on John Resig's javascript diff algorithm described here: http://ejohn.org/projects/javascript-diff-algorithm/

![diff-testfile](https://f.cloud.github.com/assets/26716/967411/7a342be2-0577-11e3-898e-844ea0f24eb2.png)

---

Known Issues
- [x] fix "stage line" behaviour when clicking on highlighted words
- [x] fix invalid diff displayed e.g. just append something at the end of a line
- [x] fix highlight of indention changes e.g. tabs to spaces: need to preserve tabs when passing diff data to javascript, currently tabs are already replaced by spaces
- [x] ~~fix diff view keeps showing "This is a large commit..." for some commits... need to figure out what's happening...~~ invalid

Bonus Todos
- ~~allow diff colors to be customized via `git config`~~ superseded by #249 
- [x] display file renames inline, e.g. very/long/path/to/{ old -> new }-filename.html
