### PR TITLE
Fix build and some lost commits.

### DIFF
--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -190,7 +190,7 @@
 {
 	[commitMessageView setEditable:YES];
 	[commitMessageView setString:@""];
-	[webController setStateMessage:[NSString stringWithFormat:[[notification userInfo] objectForKey:@"description"]]];
+	[webController setStateMessage:[NSString stringWithFormat:@"%@", [[notification userInfo] objectForKey:@"description"]]];
 }	
 
 - (void)commitFailed:(NSNotification *)notification

--- a/Classes/Controllers/PBGitHistoryController.h
+++ b/Classes/Controllers/PBGitHistoryController.h
@@ -7,10 +7,11 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import "PBGitCommit.h"
-#import "PBGitTree.h"
 #import "PBViewController.h"
-#import "PBCollapsibleSplitView.h"
+
+@class PBGitCommit;
+@class PBGitTree;
+@class PBCollapsibleSplitView;
 
 @class PBGitSidebarController;
 @class PBWebHistoryController;

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -6,6 +6,13 @@
 //  Copyright 2008 __MyCompanyName__. All rights reserved.
 //
 
+#import "PBGitSHA.h"
+#import "PBGitCommit.h"
+#import "PBGitTree.h"
+#import "PBGitRef.h"
+#import "PBGitHistoryList.h"
+#import "PBGitRevSpecifier.h"
+#import "PBCollapsibleSplitView.h"
 #import "PBGitHistoryController.h"
 #import "PBWebHistoryController.h"
 #import "CWQuickLook.h"

--- a/Classes/Controllers/PBGitSidebarController.m
+++ b/Classes/Controllers/PBGitSidebarController.m
@@ -15,6 +15,7 @@
 #import "NSOutlineViewExt.h"
 #import "PBAddRemoteSheet.h"
 #import "PBGitDefaults.h"
+#import "PBGitSubmodule.h"
 #import "PBHistorySearchController.h"
 
 @interface PBGitSidebarController ()

--- a/Classes/Controllers/PBGitSidebarController.m
+++ b/Classes/Controllers/PBGitSidebarController.m
@@ -21,8 +21,8 @@
 @interface PBGitSidebarController ()
 
 - (void)populateList;
-- (void)addRevSpec:(PBGitRevSpecifier *)revSpec;
-- (PBSourceViewItem *) itemForRev:(PBGitRevSpecifier *)rev;
+- (PBSourceViewItem *)addRevSpec:(PBGitRevSpecifier *)revSpec;
+- (PBSourceViewItem *)itemForRev:(PBGitRevSpecifier *)rev;
 - (void) removeRevSpec:(PBGitRevSpecifier *)rev;
 - (void) updateActionMenu;
 - (void) updateRemoteControls;
@@ -101,8 +101,7 @@
 		if (changeKind == NSKeyValueChangeInsertion) {
 			NSArray *newRevSpecs = [change objectForKey:NSKeyValueChangeNewKey];
 			for (PBGitRevSpecifier *rev in newRevSpecs) {
-				[self addRevSpec:rev];
-				PBSourceViewItem *item = [self itemForRev:rev];
+				PBSourceViewItem *item = [self addRevSpec:rev];
 				[sourceView PBExpandItem:item expandParents:YES];
 			}
 		}
@@ -139,25 +138,16 @@
 		[repository readCurrentBranch];
 		return;
 	}
+
+	PBSourceViewItem *item = [self addRevSpec:rev];
+    if (item) {
+        [sourceView reloadData];
 	
-	PBSourceViewItem *item = nil;
-	for (PBSourceViewItem *it in items)
-		if ( (item = [it findRev:rev]) != nil )
-			break;
+        [sourceView PBExpandItem:item expandParents:YES];
+        NSIndexSet *index = [NSIndexSet indexSetWithIndex:[sourceView rowForItem:item]];
 	
-	if (!item) {
-		[self addRevSpec:rev];
-		// Try to find the just added item again.
-		// TODO: refactor with above.
-		for (PBSourceViewItem *it in items)
-			if ( (item = [it findRev:rev]) != nil )
-				break;
-	}
-	
-	[sourceView PBExpandItem:item expandParents:YES];
-	NSIndexSet *index = [NSIndexSet indexSetWithIndex:[sourceView rowForItem:item]];
-	
-	[sourceView selectRowIndexes:index byExtendingSelection:NO];
+        [sourceView selectRowIndexes:index byExtendingSelection:NO];
+    }
 }
 
 - (PBSourceViewItem *) itemForRev:(PBGitRevSpecifier *)rev
@@ -169,12 +159,16 @@
 	return nil;
 }
 
-- (void)addRevSpec:(PBGitRevSpecifier *)rev
+- (PBSourceViewItem *)addRevSpec:(PBGitRevSpecifier *)rev
 {
+    PBSourceViewItem *item = nil;
+    for (PBSourceViewItem *it in items)
+        if ( (item = [it findRev:rev]) != nil )
+            return item;
+
 	if (![rev isSimpleRef]) {
 		[others addChild:[PBSourceViewItem itemWithRevSpec:rev]];
-		[sourceView reloadData];
-		return;
+		return item;
 	}
 
 	NSArray *pathComponents = [[rev simpleRef] componentsSeparatedByString:@"/"];
@@ -186,7 +180,7 @@
 		[tags addRev:rev toPath:[pathComponents subarrayWithRange:NSMakeRange(2, [pathComponents count] - 2)]];
 	else if ([[rev simpleRef] hasPrefix:@"refs/remotes/"])
 		[remotes addRev:rev toPath:[pathComponents subarrayWithRange:NSMakeRange(2, [pathComponents count] - 2)]];
-	[sourceView reloadData];
+    return item;
 }
 
 - (void) removeRevSpec:(PBGitRevSpecifier *)rev

--- a/Classes/Controllers/PBGitWindowController.h
+++ b/Classes/Controllers/PBGitWindowController.h
@@ -35,10 +35,10 @@
 
 - (void)changeContentController:(PBViewController *)controller;
 
-- (void)showCommitHookFailedSheet:(NSString *)messageText infoText:(NSString *)infoText commitController:(PBGitCommitController *)controller DEPRECATED;
-- (void)showMessageSheet:(NSString *)messageText infoText:(NSString *)infoText DEPRECATED;
-- (void)showErrorSheet:(NSError *)error DEPRECATED;
-- (void)showErrorSheetTitle:(NSString *)title message:(NSString *)message arguments:(NSArray *)arguments output:(NSString *)output DEPRECATED;
+- (void)showCommitHookFailedSheet:(NSString *)messageText infoText:(NSString *)infoText commitController:(PBGitCommitController *)controller GITX_DEPRECATED;
+- (void)showMessageSheet:(NSString *)messageText infoText:(NSString *)infoText GITX_DEPRECATED;
+- (void)showErrorSheet:(NSError *)error GITX_DEPRECATED;
+- (void)showErrorSheetTitle:(NSString *)title message:(NSString *)message arguments:(NSArray *)arguments output:(NSString *)output GITX_DEPRECATED;
 
 - (void)showModalSheet:(RJModalRepoSheet*)sheet;
 - (void)hideModalSheet:(RJModalRepoSheet*)sheet;

--- a/Classes/Controllers/PBHistorySearchController.m
+++ b/Classes/Controllers/PBHistorySearchController.m
@@ -6,6 +6,8 @@
 //  Copyright 2010 Nathan Kinsinger. All rights reserved.
 //
 
+#import <QuartzCore/CoreAnimation.h>
+
 #import "PBHistorySearchController.h"
 #import "PBGitHistoryController.h"
 #import "PBGitRepository.h"
@@ -13,9 +15,8 @@
 #import "PBCommitList.h"
 #import "PBEasyPipe.h"
 #import "PBGitBinary.h"
-
-#import <QuartzCore/CoreAnimation.h>
-
+#import "PBGitCommit.h"
+#import "PBGitSHA.h"
 
 @interface PBHistorySearchController ()
 

--- a/Classes/Controllers/PBRefController.m
+++ b/Classes/Controllers/PBRefController.m
@@ -442,7 +442,7 @@
 									 defaultButton:@"Move"
 								   alternateButton:@"Cancel"
 									   otherButton:nil
-						 informativeTextWithFormat:infoText];
+						 informativeTextWithFormat:@"%@", infoText];
     [alert setShowsSuppressionButton:YES];
 
 	[alert beginSheetModalForWindow:[historyController.repository.windowController window]

--- a/Classes/Controllers/PBRefController.m
+++ b/Classes/Controllers/PBRefController.m
@@ -13,8 +13,7 @@
 #import "PBCreateTagSheet.h"
 #import "PBGitDefaults.h"
 #import "PBDiffWindowController.h"
-
-#import <ObjectiveGit/ObjectiveGit.h>
+#import "PBGitRevSpecifier.h"
 
 #define kDialogAcceptDroppedRef @"Accept Dropped Ref"
 #define kDialogConfirmPush @"Confirm Push"

--- a/Classes/Controllers/PBWebHistoryController.m
+++ b/Classes/Controllers/PBWebHistoryController.m
@@ -9,7 +9,8 @@
 #import "PBWebHistoryController.h"
 #import "PBGitDefaults.h"
 #import "PBGitSHA.h"
-#import <ObjectiveGit/GTConfiguration.h>
+#import "PBGitRef.h"
+#import "PBGitRevSpecifier.h"
 
 @implementation PBWebHistoryController
 

--- a/Classes/PBCLIProxy.h
+++ b/Classes/PBCLIProxy.h
@@ -8,7 +8,6 @@
 
 #import <Cocoa/Cocoa.h>
 
-
 @interface PBCLIProxy : NSObject
 {
 	NSConnection *connection;

--- a/Classes/PBChangedFile.h
+++ b/Classes/PBChangedFile.h
@@ -7,7 +7,6 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import "PBGitRepository.h"
 
 typedef enum {
 	NEW,

--- a/Classes/PBCommitList.h
+++ b/Classes/PBCommitList.h
@@ -8,9 +8,10 @@
 
 #import <Cocoa/Cocoa.h>
 #import <WebKit/WebView.h>
-#import "PBGitHistoryController.h"
 
+@class PBGitHistoryController;
 @class PBWebHistoryController;
+@class PBHistorySearchController;
 
 typedef void(^PBFindPanelActionBlock)(id sender);
 

--- a/Classes/Util/NSString_RegEx.m
+++ b/Classes/Util/NSString_RegEx.m
@@ -42,7 +42,7 @@
 
 	if (nmatch == -1)
 	{
-		outMatches = [NSArray arrayWithObject:self];
+		outMatches = [NSMutableArray arrayWithObject:self];
 		goto catch_exit;	// simple match
 	}
 

--- a/Classes/Util/PBEasyPipe.h
+++ b/Classes/Util/PBEasyPipe.h
@@ -12,28 +12,28 @@
 
 }
 
-+ (NSTask *) taskForCommand:(NSString *)cmd withArgs:(NSArray *)args inDir:(NSString *)dir DEPRECATED;
++ (NSTask *) taskForCommand:(NSString *)cmd withArgs:(NSArray *)args inDir:(NSString *)dir GITX_DEPRECATED;
 
-+ (NSFileHandle*) handleForCommand: (NSString*) cmd withArgs: (NSArray*) args DEPRECATED;
-+ (NSFileHandle*) handleForCommand: (NSString*) cmd withArgs: (NSArray*) args inDir: (NSString*) dir DEPRECATED;
++ (NSFileHandle*) handleForCommand: (NSString*) cmd withArgs: (NSArray*) args GITX_DEPRECATED;
++ (NSFileHandle*) handleForCommand: (NSString*) cmd withArgs: (NSArray*) args inDir: (NSString*) dir GITX_DEPRECATED;
 
-+ (NSString*) outputForCommand: (NSString*) cmd withArgs: (NSArray*) args DEPRECATED;
-+ (NSString*) outputForCommand: (NSString*) cmd withArgs: (NSArray*) args inDir: (NSString*) dir DEPRECATED;
++ (NSString*) outputForCommand: (NSString*) cmd withArgs: (NSArray*) args GITX_DEPRECATED;
++ (NSString*) outputForCommand: (NSString*) cmd withArgs: (NSArray*) args inDir: (NSString*) dir GITX_DEPRECATED;
 + (NSString*) outputForCommand:(NSString *) cmd
 					  withArgs:(NSArray *)  args
 						 inDir:(NSString *) dir
-				      retValue:(int *)      ret DEPRECATED;
+				      retValue:(int *)      ret GITX_DEPRECATED;
 + (NSString*) outputForCommand:(NSString *) cmd
 					  withArgs:(NSArray *)  args
 						 inDir:(NSString *) dir
 				   inputString:(NSString *)input
-				      retValue:(int *)      ret DEPRECATED;
+				      retValue:(int *)      ret GITX_DEPRECATED;
 + (NSString*) outputForCommand:(NSString *) cmd
 					  withArgs:(NSArray *)  args
 						 inDir:(NSString *) dir
 		byExtendingEnvironment:(NSDictionary *)dict
 				   inputString:(NSString *)input
-				      retValue:(int *)      ret DEPRECATED;
+				      retValue:(int *)      ret GITX_DEPRECATED;
 
 
 @end

--- a/Classes/Views/GLFileView.h
+++ b/Classes/Views/GLFileView.h
@@ -7,13 +7,11 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import "PBWebController.h"
 #import <MGScopeBar/MGScopeBarDelegateProtocol.h>
-#import "PBGitCommit.h"
-#import "PBGitHistoryController.h"
-#import "PBRefContextDelegate.h"
 
-@class PBGitGradientBarView;
+#import "PBWebController.h"
+
+@class PBGitHistoryController;
 
 @interface GLFileView : PBWebController <MGScopeBarDelegate> {
 	IBOutlet PBGitHistoryController* historyController;

--- a/Classes/Views/GLFileView.m
+++ b/Classes/Views/GLFileView.m
@@ -6,9 +6,14 @@
 //  Copyright 2010 __MyCompanyName__. All rights reserved.
 //
 
-#import "GLFileView.h"
-#import "PBGitGradientBarView.h"
 #import <MGScopeBar/MGScopeBar.h>
+
+#import "GLFileView.h"
+#import "PBGitTree.h"
+#import "PBGitSHA.h"
+#import "PBGitCommit.h"
+#import "PBGitHistoryController.h"
+
 
 #define GROUP_LABEL				@"Label"			// string
 #define GROUP_SEPARATOR			@"HasSeparator"		// BOOL as NSNumber

--- a/Classes/Views/GitXTextFieldCell.h
+++ b/Classes/Views/GitXTextFieldCell.h
@@ -7,8 +7,8 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import "PBRefContextDelegate.h"
 
+@protocol PBRefContextDelegate;
 
 @interface GitXTextFieldCell : NSTextFieldCell {
 	IBOutlet id<PBRefContextDelegate> contextMenuDelegate;

--- a/Classes/Views/GitXTextFieldCell.m
+++ b/Classes/Views/GitXTextFieldCell.m
@@ -9,6 +9,7 @@
 #import "GitXTextFieldCell.h"
 #import "PBGitCommit.h"
 #import "PBRefController.h"
+#import "PBRefContextDelegate.h"
 
 
 @implementation GitXTextFieldCell

--- a/Classes/Views/PBCreateTagSheet.m
+++ b/Classes/Views/PBCreateTagSheet.m
@@ -9,7 +9,9 @@
 #import "PBCreateTagSheet.h"
 #import "PBGitRepository.h"
 #import "PBGitCommit.h"
+#import "PBGitRef.h"
 #import "PBGitWindowController.h"
+#import "PBGitRevSpecifier.h"
 
 @interface PBCreateTagSheet ()
 

--- a/Classes/Views/PBGitRevisionCell.m
+++ b/Classes/Views/PBGitRevisionCell.m
@@ -8,6 +8,9 @@
 
 #import "PBGitRevisionCell.h"
 #import "PBGitRef.h"
+#import "PBGitSHA.h"
+#import "PBGitCommit.h"
+#import "PBGitRevSpecifier.h"
 #import "RoundedRectangle.h"
 #import "GitXTextFieldCell.h"
 

--- a/Classes/Views/PBQLOutlineView.m
+++ b/Classes/Views/PBQLOutlineView.m
@@ -7,7 +7,7 @@
 //
 
 #import "PBQLOutlineView.h"
-
+#import "PBGitTree.h"
 
 @implementation PBQLOutlineView
 

--- a/Classes/Views/PBRefMenuItem.m
+++ b/Classes/Views/PBRefMenuItem.m
@@ -7,7 +7,9 @@
 //
 
 #import "PBRefMenuItem.h"
-
+#import "PBGitRepository.h"
+#import "PBGitRevSpecifier.h"
+#import "PBGitSHA.h"
 
 @implementation PBRefMenuItem
 @synthesize refish;

--- a/Classes/git/PBGitCommit.h
+++ b/Classes/git/PBGitCommit.h
@@ -7,17 +7,16 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import "PBGitRepository.h"
-#import "PBGitTree.h"
-#import "PBGitRefish.h"
-#import "PBGitSHA.h"
+#import "PBGitRefish.h" // for @protocol PBGitRefish
 
-#import <ObjectiveGit/git2/oid.h>
+@class PBGitRepository;
+@class PBGitTree;
+@class PBGitRef;
+@class PBGitSHA;
+@class PBGraphCellInfo;
 
 extern NSString * const kGitXCommitType;
 
-@class PBGraphCellInfo;
-@class GTCommit;
 
 @interface PBGitCommit : NSObject <PBGitRefish>
 

--- a/Classes/git/PBGitCommit.m
+++ b/Classes/git/PBGitCommit.m
@@ -6,11 +6,12 @@
 //  Copyright 2008 __MyCompanyName__. All rights reserved.
 //
 
+#import "PBGitRepository.h"
 #import "PBGitCommit.h"
+#import "PBGitTree.h"
 #import "PBGitSHA.h"
+#import "PBGitRef.h"
 #import "PBGitDefaults.h"
-
-#import <ObjectiveGit/ObjectiveGit.h>
 
 NSString * const kGitXCommitType = @"commit";
 

--- a/Classes/git/PBGitGrapher.mm
+++ b/Classes/git/PBGitGrapher.mm
@@ -6,15 +6,15 @@
 //  Copyright 2008 __MyCompanyName__. All rights reserved.
 //
 
+#include <vector>
+#include <algorithm>
+
 #import "PBGraphCellInfo.h"
 #import "PBGitGrapher.h"
 #import "PBGitCommit.h"
+#import "PBGitSHA.h"
 #import "PBGitLane.h"
 #import "PBGitGraphLine.h"
-
-#import <vector>
-#import <git2/oid.h>
-#include <algorithm>
 
 using namespace std;
 typedef std::vector<PBGitLane *> LaneCollection;

--- a/Classes/git/PBGitHistoryList.m
+++ b/Classes/git/PBGitHistoryList.m
@@ -12,8 +12,8 @@
 #import "PBGitGrapher.h"
 #import "PBGitHistoryGrapher.h"
 #import "PBGitSHA.h"
-
-
+#import "PBGitRef.h"
+#import "PBGitRevSpecifier.h"
 
 @interface PBGitHistoryList ()
 

--- a/Classes/git/PBGitLane.h
+++ b/Classes/git/PBGitLane.h
@@ -5,8 +5,8 @@
 //  Created by Pieter de Bie on 27-08-08.
 //  Copyright 2008 __MyCompanyName__. All rights reserved.
 //
+
 #import <Cocoa/Cocoa.h>
-#include <git2/oid.h>
 
 class PBGitLane {
 	static int s_colorIndex;

--- a/Classes/git/PBGitRef.h
+++ b/Classes/git/PBGitRef.h
@@ -9,7 +9,6 @@
 #import <Cocoa/Cocoa.h>
 #import "PBGitRefish.h"
 
-
 extern NSString * const kGitXTagType;
 extern NSString * const kGitXBranchType;
 extern NSString * const kGitXRemoteType;

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -7,10 +7,11 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import "PBGitHistoryList.h"
-#import "PBGitRevSpecifier.h"
-#import "PBGitRefish.h"
 
+@class PBGitHistoryList;
+@class PBGitRevSpecifier;
+@protocol PBGitRefish;
+@class PBGitRef;
 @class GTRepository;
 @class GTConfiguration;
 

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -86,21 +86,21 @@ static NSString * PBStringFromBranchFilterType(PBGitXBranchFilterType type) {
 
 - (NSURL *) gitURL ;
 
-- (NSFileHandle*) handleForCommand:(NSString*) cmd DEPRECATED;
-- (NSFileHandle*) handleForArguments:(NSArray*) args DEPRECATED;
-- (NSFileHandle *) handleInWorkDirForArguments:(NSArray *)args DEPRECATED;
-- (NSString*) outputForCommand:(NSString*) cmd DEPRECATED;
-- (NSString *)outputForCommand:(NSString *)str retValue:(int *)ret DEPRECATED;
-- (NSString *)outputForArguments:(NSArray *)arguments inputString:(NSString *)input retValue:(int *)ret DEPRECATED;
-- (NSString *)outputForArguments:(NSArray *)arguments inputString:(NSString *)input byExtendingEnvironment:(NSDictionary *)dict retValue:(int *)ret DEPRECATED;
+- (NSFileHandle*) handleForCommand:(NSString*) cmd GITX_DEPRECATED;
+- (NSFileHandle*) handleForArguments:(NSArray*) args GITX_DEPRECATED;
+- (NSFileHandle *) handleInWorkDirForArguments:(NSArray *)args GITX_DEPRECATED;
+- (NSString*) outputForCommand:(NSString*) cmd GITX_DEPRECATED;
+- (NSString *)outputForCommand:(NSString *)str retValue:(int *)ret GITX_DEPRECATED;
+- (NSString *)outputForArguments:(NSArray *)arguments inputString:(NSString *)input retValue:(int *)ret GITX_DEPRECATED;
+- (NSString *)outputForArguments:(NSArray *)arguments inputString:(NSString *)input byExtendingEnvironment:(NSDictionary *)dict retValue:(int *)ret GITX_DEPRECATED;
 
 
-- (NSString*) outputForArguments:(NSArray*) args DEPRECATED;
-- (NSString*) outputForArguments:(NSArray*) args retValue:(int *)ret DEPRECATED;
-- (NSString *)outputInWorkdirForArguments:(NSArray*) arguments DEPRECATED;
-- (NSString *)outputInWorkdirForArguments:(NSArray*) arguments retValue:(int *)ret DEPRECATED;
-- (BOOL)executeHook:(NSString *)name output:(NSString **)output DEPRECATED;
-- (BOOL)executeHook:(NSString *)name withArgs:(NSArray*) arguments output:(NSString **)output DEPRECATED;
+- (NSString*) outputForArguments:(NSArray*) args GITX_DEPRECATED;
+- (NSString*) outputForArguments:(NSArray*) args retValue:(int *)ret GITX_DEPRECATED;
+- (NSString *)outputInWorkdirForArguments:(NSArray*) arguments GITX_DEPRECATED;
+- (NSString *)outputInWorkdirForArguments:(NSArray*) arguments retValue:(int *)ret GITX_DEPRECATED;
+- (BOOL)executeHook:(NSString *)name output:(NSString **)output GITX_DEPRECATED;
+- (BOOL)executeHook:(NSString *)name withArgs:(NSArray*) arguments output:(NSString **)output GITX_DEPRECATED;
 
 - (NSString *)workingDirectory;
 - (NSString *) projectName;

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -23,10 +23,9 @@
 #import "PBGitRepositoryWatcher.h"
 #import "GitRepoFinder.h"
 #import "PBGitSubmodule.h"
+#import "PBGitHistoryList.h"
+#import "PBGitSHA.h"
 
-#import <ObjectiveGit/GTRepository.h>
-#import <ObjectiveGit/GTIndex.h>
-#import <ObjectiveGit/GTConfiguration.h>
 
 NSString *PBGitRepositoryDocumentType = @"Git Repository";
 

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -269,28 +269,13 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 	}
 }
 
-int addSubmoduleName(git_submodule *module, const char* name, void * context)
-{
-    PBGitRepository *me = (__bridge PBGitRepository *)context;
-    PBGitSubmodule *sub = [[PBGitSubmodule alloc] init];
-    [sub setWorkingDirectory:me.workingDirectory];
-    [sub setSubmodule:module];
-    
-
-    [me.submodules addObject:sub];
-    
-    return 0;
-}
-
-- (void) loadSubmodules
+- (void)loadSubmodules
 {
     self.submodules = [NSMutableArray array];
-	git_repository* theRepo = self.gtRepo.git_repository;
-	if (!theRepo)
-	{
-		return;
-	}
-    git_submodule_foreach(theRepo, addSubmoduleName, (__bridge void *)self);
+
+    [self.gtRepo enumerateSubmodulesRecursively:NO usingBlock:^(GTSubmodule *submodule, BOOL *stop) {
+        [self.submodules addObject:submodule];
+    }];
 }
 
 - (void) reloadRefs

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -40,31 +40,29 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 @synthesize revisionList, branchesSet, currentBranch, refs, hasChanged, submodules;
 @synthesize currentBranchFilter;
 
-- (BOOL) isBareRepository
+#pragma mark -
+#pragma mark Memory management
+
+- (id)init
 {
-    return self.gtRepo.isBare;
+    self = [super init];
+    if (!self) return nil;
+
+	self.branchesSet = [NSMutableOrderedSet orderedSet];
+    self.submodules = [NSMutableArray array];
+	currentBranchFilter = [PBGitDefaults branchFilter];
+    return self;
 }
 
-- (BOOL) readHasSVNRemoteFromConfig
+- (void) dealloc
 {
-	NSError *error = nil;
-	GTConfiguration *config = [self.gtRepo configurationWithError:&error];
-	NSArray *allKeys = config.configurationKeys;
-	for (NSString *key in allKeys) {
-		if ([key hasPrefix:@"svn-remote."]) {
-			return TRUE;
-		}
-	}
-	return false;
+	NSLog(@"Dealloc of repository");
+	[watcher stop];
 }
 
-- (BOOL) hasSVNRemote
-{
-	if (!self.hasSVNRepoConfig) {
-		self.hasSVNRepoConfig = @([self readHasSVNRemoteFromConfig]);
-	}
-	return [self.hasSVNRepoConfig boolValue];
-}
+
+#pragma mark -
+#pragma mark NSDocument API
 
 // NSFileWrapper is broken and doesn't work when called on a directory containing a large number of directories and files.
 //because of this it is safer to implement readFromURL than readFromFileWrapper.
@@ -116,22 +114,6 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 	return YES;
 }
 
-- (NSURL *) gitURL {
-    return self.gtRepo.gitDirectoryURL;
-}
-
-- (id) init
-{
-    self = [super init];
-    if (!self)
-        return nil;
-
-	self.branchesSet = [NSMutableOrderedSet orderedSet];
-    self.submodules = [NSMutableArray array];
-	currentBranchFilter = [PBGitDefaults branchFilter];
-    return self;
-}
-
 - (void)close
 {
 	[revisionList cleanup];
@@ -139,43 +121,116 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 	[super close];
 }
 
-- (void) forceUpdateRevisions
-{
-	[revisionList forceUpdate];
-}
-
 - (BOOL)isDocumentEdited
 {
 	return NO;
 }
 
-// The fileURL the document keeps is to the working dir
-- (NSString *) displayName
+- (NSString *)displayName
 {
+    // Build our display name depending on the current HEAD and whether it's detached or not
     if (self.gtRepo.isHEADDetached)
-		return [NSString stringWithFormat:@"%@ (detached HEAD)", [self projectName]];
+		return [NSString localizedStringWithFormat:@"%@ (detached HEAD)", self.projectName];
 
-	return [NSString stringWithFormat:@"%@ (branch: %@)", [self projectName], [[self headRef] description]];
+	return [NSString localizedStringWithFormat:@"%@ (branch: %@)", self.projectName, [[self headRef] description]];
 }
 
-- (NSString *) projectName
+- (void)makeWindowControllers
+{
+    // Create our custom window controller
+#ifndef CLI
+	[self addWindowController: [[PBGitWindowController alloc] initWithRepository:self displayDefault:YES]];
+#endif
+}
+
+// see if the current appleEvent has the command line arguments from the gitx cli
+// this could be from an openApplication or an openDocument apple event
+// when opening a repository this is called before the sidebar controller gets it's awakeFromNib: message
+// if the repository is already open then this is also a good place to catch the event as the window is about to be brought forward
+- (void)showWindows
+{
+	NSAppleEventDescriptor *currentAppleEvent = [[NSAppleEventManager sharedAppleEventManager] currentAppleEvent];
+
+	if (currentAppleEvent) {
+		NSAppleEventDescriptor *eventRecord = [currentAppleEvent paramDescriptorForKeyword:keyAEPropData];
+
+		// on app launch there may be many repositories opening, so double check that this is the right repo
+		NSString *path = [[eventRecord paramDescriptorForKeyword:typeFileURL] stringValue];
+		if (path) {
+			NSURL *workingDirectory = [NSURL URLWithString:path];
+			if ([[GitRepoFinder gitDirForURL:workingDirectory] isEqual:[self fileURL]]) {
+				NSAppleEventDescriptor *argumentsList = [eventRecord paramDescriptorForKeyword:kGitXAEKeyArgumentsList];
+				[self handleGitXScriptingArguments:argumentsList inWorkingDirectory:workingDirectory];
+
+				// showWindows may be called more than once during app launch so remove the CLI data after we handle the event
+				[currentAppleEvent removeDescriptorWithKeyword:keyAEPropData];
+			}
+		}
+	}
+
+	[super showWindows];
+}
+
+#pragma mark -
+#pragma mark Properties/General methods
+
+- (NSURL *)getIndexURL
+{
+	NSError *error = nil;
+	GTIndex *index = [self.gtRepo indexWithError:&error];
+    if (index == nil) {
+        NSLog(@"getIndexURL failed with error %@", error);
+        return nil;
+    }
+	NSURL* result = index.fileURL;
+	return result;
+}
+
+- (BOOL)isBareRepository
+{
+    return self.gtRepo.isBare;
+}
+
+- (BOOL)readHasSVNRemoteFromConfig
+{
+	NSError *error = nil;
+	GTConfiguration *config = [self.gtRepo configurationWithError:&error];
+	NSArray *allKeys = config.configurationKeys;
+	for (NSString *key in allKeys) {
+		if ([key hasPrefix:@"svn-remote."]) {
+			return TRUE;
+		}
+	}
+	return false;
+}
+
+- (BOOL)hasSVNRemote
+{
+	if (!self.hasSVNRepoConfig) {
+		self.hasSVNRepoConfig = @([self readHasSVNRemoteFromConfig]);
+	}
+	return [self.hasSVNRepoConfig boolValue];
+}
+
+- (NSURL *)gitURL {
+    return self.gtRepo.gitDirectoryURL;
+}
+
+- (void)forceUpdateRevisions
+{
+	[revisionList forceUpdate];
+}
+
+- (NSString *)projectName
 {
 	NSString* result = [self.workingDirectory lastPathComponent];
 	return result;
 }
 
 // Get the .gitignore file at the root of the repository
-- (NSString*)gitIgnoreFilename
+- (NSString *)gitIgnoreFilename
 {
 	return [[self workingDirectory] stringByAppendingPathComponent:@".gitignore"];
-}
-
-// Overridden to create our custom window controller
-- (void)makeWindowControllers
-{
-#ifndef CLI
-	[self addWindowController: [[PBGitWindowController alloc] initWithRepository:self displayDefault:YES]];
-#endif
 }
 
 - (PBGitWindowController *)windowController
@@ -186,7 +241,7 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 	return [[self windowControllers] objectAtIndex:0];
 }
 
-- (void) addRef:(GTReference*)gtRef
+- (void)addRef:(GTReference *)gtRef
 {
 	GTObject *refTarget = gtRef.resolvedTarget;
 	if (![refTarget isKindOfClass:[GTObject class]]) {
@@ -992,34 +1047,6 @@ int addSubmoduleName(git_submodule *module, const char* name, void * context)
 	[self handleRevListArguments:arguments inWorkingDirectory:workingDirectory];
 }
 
-// see if the current appleEvent has the command line arguments from the gitx cli
-// this could be from an openApplication or an openDocument apple event
-// when opening a repository this is called before the sidebar controller gets it's awakeFromNib: message
-// if the repository is already open then this is also a good place to catch the event as the window is about to be brought forward
-- (void)showWindows
-{
-	NSAppleEventDescriptor *currentAppleEvent = [[NSAppleEventManager sharedAppleEventManager] currentAppleEvent];
-
-	if (currentAppleEvent) {
-		NSAppleEventDescriptor *eventRecord = [currentAppleEvent paramDescriptorForKeyword:keyAEPropData];
-
-		// on app launch there may be many repositories opening, so double check that this is the right repo
-		NSString *path = [[eventRecord paramDescriptorForKeyword:typeFileURL] stringValue];
-		if (path) {
-			NSURL *workingDirectory = [NSURL URLWithString:path];
-			if ([[GitRepoFinder gitDirForURL:workingDirectory] isEqual:[self fileURL]]) {
-				NSAppleEventDescriptor *argumentsList = [eventRecord paramDescriptorForKeyword:kGitXAEKeyArgumentsList];
-				[self handleGitXScriptingArguments:argumentsList inWorkingDirectory:workingDirectory];
-
-				// showWindows may be called more than once during app launch so remove the CLI data after we handle the event
-				[currentAppleEvent removeDescriptorWithKeyword:keyAEPropData];
-			}
-		}
-	}
-
-	[super showWindows];
-}
-
 // for the scripting bridge
 - (void)findInModeScriptCommand:(NSScriptCommand *)command
 {
@@ -1161,18 +1188,4 @@ int addSubmoduleName(git_submodule *module, const char* name, void * context)
 	return nil;
 }
 
-- (NSURL*) getIndexURL
-{
-	NSError *error = nil;
-	GTIndex *index = [self.gtRepo indexWithError:&error];
-	NSURL* result = index.fileURL;
-	return result;
-}
-
-
-- (void) dealloc
-{
-	NSLog(@"Dealloc of repository");
-	[watcher stop];
-}
 @end

--- a/Classes/git/PBGitRepositoryWatcher.h
+++ b/Classes/git/PBGitRepositoryWatcher.h
@@ -9,7 +9,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "PBGitRepository.h"
+@class PBGitRepository;
 
 typedef UInt32 PBGitRepositoryWatcherEventType;
 enum {

--- a/Classes/git/PBGitRepositoryWatcher.m
+++ b/Classes/git/PBGitRepositoryWatcher.m
@@ -6,17 +6,16 @@
 //  Copyright 2009 __MyCompanyName__. All rights reserved.
 //
 #import <CoreServices/CoreServices.h>
+
 #import "PBGitRepositoryWatcher.h"
+#import "PBGitRepository.h"
 #import "PBEasyPipe.h"
 #import "PBGitDefaults.h"
 #import "PBGitRepositoryWatcherEventPath.h"
 
-#import <ObjectiveGit/ObjectiveGit.h>
-
 NSString *PBGitRepositoryEventNotification = @"PBGitRepositoryModifiedNotification";
 NSString *kPBGitRepositoryEventTypeUserInfoKey = @"kPBGitRepositoryEventTypeUserInfoKey";
 NSString *kPBGitRepositoryEventPathsUserInfoKey = @"kPBGitRepositoryEventPathsUserInfoKey";
-
 
 @interface PBGitRepositoryWatcher ()
 

--- a/Classes/git/PBGitRevList.mm
+++ b/Classes/git/PBGitRevList.mm
@@ -225,6 +225,11 @@ using namespace std;
 	
 	dispatch_group_wait(loadGroup, DISPATCH_TIME_FOREVER);
 	dispatch_group_wait(decorateGroup, DISPATCH_TIME_FOREVER);
+
+    dispatch_release(loadGroup);
+    dispatch_release(decorateGroup);
+    dispatch_release(loadQueue);
+    dispatch_release(decorateQueue);
 	
 	// Make sure the commits are stored before exiting.
 	NSDictionary *update = [NSDictionary dictionaryWithObjectsAndKeys:currentThread, kRevListThreadKey, revisions, kRevListRevisionsKey, nil];

--- a/Classes/git/PBGitRevSpecifier.h
+++ b/Classes/git/PBGitRevSpecifier.h
@@ -7,7 +7,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import "PBGitRef.h"
+@class PBGitRef;
 
 @interface PBGitRevSpecifier : NSObject  <NSCopying> {
 	NSString *description;

--- a/Classes/git/PBGitRevSpecifier.m
+++ b/Classes/git/PBGitRevSpecifier.m
@@ -19,6 +19,7 @@
 - (id) initWithParameters:(NSArray *)params description:(NSString *)descrip
 {
     self = [super init];
+    if (!self) return nil;
 	parameters = params;
 	description = descrip;
 
@@ -39,23 +40,17 @@
 
 - (id) initWithParameters:(NSArray *)params
 {
-    self = [super init];
-	self = [self initWithParameters:params description:nil];
-	return self;
+	return [self initWithParameters:params description:nil];
 }
 
 - (id) initWithRef:(PBGitRef *)ref
 {
-    self = [super init];
-	self = [self initWithParameters:[NSArray arrayWithObject:ref.ref] description:ref.shortName];
-	return self;
+	return [self initWithParameters:[NSArray arrayWithObject:ref.ref] description:ref.shortName];
 }
 
 - (id) initWithCoder:(NSCoder *)coder
 {
-    self = [super init];
-	self = [self initWithParameters:[coder decodeObjectForKey:@"Parameters"] description:[coder decodeObjectForKey:@"Description"]];
-	return self;
+	return [self initWithParameters:[coder decodeObjectForKey:@"Parameters"] description:[coder decodeObjectForKey:@"Description"]];
 }
 
 + (PBGitRevSpecifier *)allBranchesRevSpec

--- a/Classes/git/PBGitRevSpecifier.m
+++ b/Classes/git/PBGitRevSpecifier.m
@@ -7,7 +7,7 @@
 //
 
 #import "PBGitRevSpecifier.h"
-
+#import "PBGitRef.h"
 
 @implementation PBGitRevSpecifier
 

--- a/Classes/git/PBGitSHA.h
+++ b/Classes/git/PBGitSHA.h
@@ -7,8 +7,6 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#include <git2/oid.h>
-
 
 @interface PBGitSHA : NSObject <NSCopying>
 

--- a/Classes/git/PBGitSHA.m
+++ b/Classes/git/PBGitSHA.m
@@ -8,8 +8,6 @@
 
 #import "PBGitSHA.h"
 
-#import <git2/errors.h>
-
 @interface PBGitSHA ()
 
 @property (nonatomic, assign) git_oid oid;

--- a/Classes/git/PBGitSVBranchItem.h
+++ b/Classes/git/PBGitSVBranchItem.h
@@ -9,7 +9,6 @@
 #import <Cocoa/Cocoa.h>
 #import "PBSourceViewItem.h"
 
-
 @interface PBGitSVBranchItem : PBSourceViewItem {
 
 }

--- a/Classes/git/PBGitSVFolderItem.h
+++ b/Classes/git/PBGitSVFolderItem.h
@@ -9,7 +9,6 @@
 #import <Cocoa/Cocoa.h>
 #import "PBSourceViewItem.h"
 
-
 @interface PBGitSVFolderItem : PBSourceViewItem {
 
 }

--- a/Classes/git/PBGitSVOtherRevItem.h
+++ b/Classes/git/PBGitSVOtherRevItem.h
@@ -9,7 +9,6 @@
 #import <Cocoa/Cocoa.h>
 #import "PBSourceViewItem.h"
 
-
 @interface PBGitSVOtherRevItem : PBSourceViewItem {
 
 }

--- a/Classes/git/PBGitSVRemoteBranchItem.h
+++ b/Classes/git/PBGitSVRemoteBranchItem.h
@@ -9,7 +9,6 @@
 #import <Cocoa/Cocoa.h>
 #import "PBSourceViewItem.h"
 
-
 @interface PBGitSVRemoteBranchItem : PBSourceViewItem {
 
 }

--- a/Classes/git/PBGitSVRemoteItem.h
+++ b/Classes/git/PBGitSVRemoteItem.h
@@ -9,7 +9,6 @@
 #import <Cocoa/Cocoa.h>
 #import "PBSourceViewItem.h"
 
-
 @interface PBGitSVRemoteItem : PBSourceViewItem {
 
 }

--- a/Classes/git/PBGitSVStageItem.h
+++ b/Classes/git/PBGitSVStageItem.h
@@ -9,7 +9,6 @@
 #import <Cocoa/Cocoa.h>
 #import "PBSourceViewItem.h"
 
-
 @interface PBGitSVStageItem : PBSourceViewItem {
 
 }

--- a/Classes/git/PBGitSVSubmoduleItem.h
+++ b/Classes/git/PBGitSVSubmoduleItem.h
@@ -8,7 +8,9 @@
 
 #import <Foundation/Foundation.h>
 #import "PBSourceViewItem.h"
-#import "PBGitSubmodule.h"
+
+@class PBGitSubmodule;
+
 @interface PBGitSVSubmoduleItem : PBSourceViewItem
 + (id) itemWithSubmodule:(PBGitSubmodule*)submodule;
 @property (nonatomic, strong) PBGitSubmodule* submodule;

--- a/Classes/git/PBGitSVSubmoduleItem.m
+++ b/Classes/git/PBGitSVSubmoduleItem.m
@@ -7,6 +7,7 @@
 //
 
 #import "PBGitSVSubmoduleItem.h"
+#import "PBGitSubmodule.h"
 
 @implementation PBGitSVSubmoduleItem
 

--- a/Classes/git/PBGitSVTagItem.h
+++ b/Classes/git/PBGitSVTagItem.h
@@ -9,7 +9,6 @@
 #import <Cocoa/Cocoa.h>
 #import "PBSourceViewItem.h"
 
-
 @interface PBGitSVTagItem : PBSourceViewItem {
 
 }

--- a/Classes/git/PBGitTree.h
+++ b/Classes/git/PBGitTree.h
@@ -7,7 +7,8 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import "PBGitRepository.h"
+
+@class PBGitRepository;
 
 @interface PBGitTree : NSObject {
 	long long _fileSize;

--- a/Classes/git/PBGitTree.m
+++ b/Classes/git/PBGitTree.m
@@ -6,6 +6,7 @@
 //  Copyright 2008 __MyCompanyName__. All rights reserved.
 //
 
+#import "PBGitRepository.h"
 #import "PBGitTree.h"
 #import "PBGitCommit.h"
 #import "NSFileHandleExt.h"

--- a/Classes/git/PBGitXProtocol.h
+++ b/Classes/git/PBGitXProtocol.h
@@ -7,7 +7,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import "PBGitRepository.h"
+@class PBGitRepository;
 
 @interface PBGitXProtocol : NSURLProtocol {
 	NSFileHandle *handle;

--- a/Classes/git/PBGitXProtocol.m
+++ b/Classes/git/PBGitXProtocol.m
@@ -7,7 +7,7 @@
 //
 
 #import "PBGitXProtocol.h"
-
+#import "PBGitRepository.h"
 
 @implementation PBGitXProtocol
 

--- a/GitX.h
+++ b/GitX.h
@@ -28,7 +28,7 @@
 - (void) quit;  // Quit the application.
 - (BOOL) exists:(id)x;  // Verify that an object exists.
 - (void) showDiff:(NSString *)x;  // Show the supplied diff output in a GitX window.
-- (void) initRepository:(NSURL *)x;  // Create a git repository at the given filesystem URL.
+- (void) initRepository:(NSURL *)x NS_RETURNS_NOT_RETAINED;  // Create a git repository at the given filesystem URL.
 - (void) cloneRepository:(NSString *)x to:(NSURL *)to isBare:(BOOL)isBare;  // Clone a repository.
 
 @end

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		4A0B5BD215FE2DA600ACCB61 /* libssl.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libssl.dylib; path = usr/lib/libssl.dylib; sourceTree = SDKROOT; };
 		4A0B5BD415FE2DC900ACCB61 /* libcrypto.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcrypto.dylib; path = usr/lib/libcrypto.dylib; sourceTree = SDKROOT; };
-		4A1223321765D1DD0041B567 /* libgit2 */ = {isa = PBXFileReference; lastKnownFileType = folder; name = libgit2; path = "objective-git/libgit2"; sourceTree = "<group>"; };
+		4A1223321765D1DD0041B567 /* libgit2 */ = {isa = PBXFileReference; lastKnownFileType = folder; name = libgit2; path = "objective-git/External/libgit2"; sourceTree = "<group>"; };
 		4A2125A217C0C78A00B5B582 /* NSColor+RGB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSColor+RGB.h"; sourceTree = "<group>"; };
 		4A2125A317C0C78A00B5B582 /* NSColor+RGB.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSColor+RGB.m"; sourceTree = "<group>"; };
 		4A40159614067B6300DB9C07 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };

--- a/GitX_Prefix.pch
+++ b/GitX_Prefix.pch
@@ -5,4 +5,8 @@
     #import <ObjectiveGit/ObjectiveGit.h>
 #endif
 
-#define DEPRECATED __attribute__ ((deprecated))
+#ifdef GITX_NO_DEPRECATE
+#define GITX_DEPRECATED
+#else
+#define GITX_DEPRECATED __attribute__ ((deprecated))
+#endif

--- a/GitX_Prefix.pch
+++ b/GitX_Prefix.pch
@@ -2,9 +2,7 @@
 
 #ifdef __OBJC__
     #import <Cocoa/Cocoa.h>
-	#ifndef __cplusplus
-		#import <ObjectiveGit/ObjectiveGit.h>
-	#endif
+    #import <ObjectiveGit/ObjectiveGit.h>
 #endif
 
 #define DEPRECATED __attribute__ ((deprecated))


### PR DESCRIPTION
This fixes (partly) the build under Xcode 5. The "partly" is due to Sparkle still relying on the 10.7 SDK, which I don't have anymore (Xcode 5 took care of it).

I reworked most `#import`s to be more "standard" (see 0578665), and added a few commits I had lying around.

This also depends on https://github.com/andymatuschak/Sparkle/pull/298 for a hard error under Xcode 5.
