### PR TITLE
Fix crash on cancelling the File->New dialog

### DIFF
--- a/Classes/Controllers/PBRepositoryDocumentController.m
+++ b/Classes/Controllers/PBRepositoryDocumentController.m
@@ -34,8 +34,10 @@
 	[op setAllowsMultipleSelection:NO];
 	[op setMessage:@"Initialize a repository here:"];
 	[op setTitle:@"New Repository"];
-	if ([op runModal] != NSFileHandlingPanelOKButton)
+    if ([op runModal] != NSFileHandlingPanelOKButton) {
+        *outError = nil;
         return nil;
+    }
 
     BOOL success = [GTRepository initializeEmptyRepositoryAtFileURL:[op URL] error:outError];
     if (!success)


### PR DESCRIPTION
When I want to open a recent window, I often hit ⌘N ⎋ without thinking about it, which causes a crash as AppKit inspects the uninitialized `outError` to find out why PBRepositoryDocumentController didn't create a document.

This commit fixes the crash.  You now get "No document could be created." on hitting File->New, then Cancel - it appears to be impossible to silently return nil from `makeUntitledDocumentOfType`.
