### PR TITLE
Added "/usr/bin/git" to the searchLocations.

### DIFF
--- a/Classes/git/PBGitBinary.m
+++ b/Classes/git/PBGitBinary.m
@@ -114,6 +114,7 @@ static NSMutableArray *locations = nil;
 					 nil];
 		
 		[locations addObject:[@"~/bin/git" stringByExpandingTildeInPath]];
+		[locations addObject:@"/usr/bin/git"];
 	}
 	return locations;
 }


### PR DESCRIPTION
I use the git version that is shipped with Xcode, which resides in "/usr/bin/git". When trying to open a repository I got this error message:

Could not find a git binary version 1.6.0 or higher.
Please make sure there is a git binary in one of the following locations:

```
/opt/local/bin/git
/sw/bin/git
/opt/git/bin/git
/usr/local/bin/git
/usr/local/git/bin/git
/Users/bler/bin/git
```

I did not feel like moving my git binary, so I added my location to the list. Considering that my location is the default location for git on OS X I really think it should be in this list. I was surprised that it wasn't.
