### PR TITLE
Patch/remove label shadows

### DIFF
--- a/Classes/Views/PBGitRevisionCell.m
+++ b/Classes/Views/PBGitRevisionCell.m
@@ -17,7 +17,7 @@
 #import "NSColor+RGB.h"
 
 const int COLUMN_WIDTH = 10;
-const BOOL ENABLE_SHADOW = YES;
+const BOOL ENABLE_SHADOW = NO;
 const BOOL SHUFFLE_COLORS = NO;
 
 @implementation PBGitRevisionCell
@@ -55,23 +55,35 @@ const BOOL SHUFFLE_COLORS = NO;
 	return laneColors;
 }
 
-+ (NSColor *)shadowColor
++ (NSShadow *)shadow
 {
-	static NSColor *shadowColor = nil;
-	if (!shadowColor) {
-		uint8_t l = 64;
-		shadowColor = [NSColor colorWithR:l G:l B:l];
+	static NSShadow *shadow = nil;
+	if (!shadow) {
+		shadow = [NSShadow new];
+		[shadow setShadowOffset:NSMakeSize(.5, -.5)];
+		[shadow setShadowBlurRadius:2];
+		[shadow setShadowColor:[NSColor colorWithWhite:0 alpha:.7]];
 	}
-	return shadowColor;
+	return shadow;
 }
-+ (NSColor *)lineShadowColor
++ (NSShadow *)textInsetShadow
 {
-	static NSColor *shadowColor = nil;
-	if (!shadowColor) {
-		uint8_t l = 200;
-		shadowColor = [NSColor colorWithR:l G:l B:l];
+	static NSShadow *shadow = nil;
+	if (!shadow) {
+		shadow = [NSShadow new];
+		[shadow setShadowOffset:NSMakeSize(0, -.5)];
+		[shadow setShadowBlurRadius:0];
+		[shadow setShadowColor:[NSColor colorWithWhite:1 alpha:.5]];
 	}
-	return shadowColor;
+	return shadow;
+}
++ (NSShadow *)lineShadow
+{
+	static NSShadow *shadow = nil;
+	if (!shadow) {
+		shadow = [NSShadow new];
+	}
+	return shadow;
 }
 
 - (void) drawLineFromColumn: (int) from toColumn: (int) to inRect: (NSRect) r offset: (int) offset color: (int) c
@@ -81,14 +93,9 @@ const BOOL SHUFFLE_COLORS = NO;
 	NSPoint source = NSMakePoint(origin.x + COLUMN_WIDTH * from, origin.y + offset);
 	NSPoint center = NSMakePoint( origin.x + COLUMN_WIDTH * to, origin.y + r.size.height * 0.5 + 0.5);
 
-	if (ENABLE_SHADOW)
-	{
+	if (ENABLE_SHADOW) {
 		[NSGraphicsContext saveGraphicsState];
-
-		NSShadow *shadow = [NSShadow new];
-		[shadow setShadowColor:[[self class] lineShadowColor]];
-		[shadow setShadowOffset:NSMakeSize(0.5f, -0.5f)];
-		[shadow set];
+		[[[self class] lineShadow] set];
 	}
 	NSArray* colors = [PBGitRevisionCell laneColors];
 	[(NSColor*)[colors objectAtIndex: (c % [colors count])] set];
@@ -126,11 +133,8 @@ const BOOL SHUFFLE_COLORS = NO;
 	NSBezierPath * path = [NSBezierPath bezierPathWithOvalInRect:oval];
 	if (ENABLE_SHADOW && false) {
 		[NSGraphicsContext saveGraphicsState];
-		NSShadow *shadow = [NSShadow new];
-		[shadow setShadowColor:[[self class] shadowColor]];
-		[shadow setShadowOffset:NSMakeSize(0.5f, -0.5f)];
-		[shadow setShadowBlurRadius:2.0f];
-		[shadow set];
+		[[[self class] shadow] set];
+		[[NSColor blackColor] set];
 	}
 	[[NSColor blackColor] set];
 	[path fill];
@@ -192,19 +196,12 @@ const BOOL SHUFFLE_COLORS = NO;
 	[attributes setObject:style forKey:NSParagraphStyleAttributeName];
 	[attributes setObject:[NSFont fontWithName:@"LucidaGrande" size:10] forKey:NSFontAttributeName];
 
-	NSShadow *shadow = nil;
-
 	if (selected && false) { // white text is a bit too hard to read (even with shadow) on refs
 		[attributes setObject:[NSColor alternateSelectedControlTextColor] forKey:NSForegroundColorAttributeName];
-		if (ENABLE_SHADOW) {
-			shadow = [NSShadow new];
-			[shadow setShadowColor:[NSColor blackColor]];
-			[shadow setShadowBlurRadius:2.0f];
-		}
 	}
 
-	if (shadow) {
-		attributes[NSShadowAttributeName] = shadow;
+	if (ENABLE_SHADOW) {
+		attributes[NSShadowAttributeName] = [[self class] textInsetShadow];
 	}
 
 	return attributes;
@@ -272,12 +269,7 @@ const BOOL SHUFFLE_COLORS = NO;
 
 	if (ENABLE_SHADOW) {
 		[NSGraphicsContext saveGraphicsState];
-
-		NSShadow *shadow = [NSShadow new];
-		[shadow setShadowColor:[NSColor grayColor]];//[[self class] shadowColor]];
-		[shadow setShadowOffset:NSMakeSize(0.5f, -0.5f)];
-		[shadow setShadowBlurRadius:2.0f];
-		[shadow set];
+		[[[self class] shadow] set];
 	}
 	[border fill];
 	if (ENABLE_SHADOW) {

--- a/Classes/Views/PBGitRevisionCell.m
+++ b/Classes/Views/PBGitRevisionCell.m
@@ -122,11 +122,11 @@ const BOOL SHUFFLE_COLORS = NO;
 	return [currentSha isEqual:thisSha];
 }
 
-- (void) drawCircleInRect: (NSRect) r
+- (void) drawCircleInRect: (NSRect) r color: (int) c
 {
-	int c = cellInfo.position;
+	int p = cellInfo.position;
 	NSPoint origin = r.origin;
-	NSPoint columnOrigin = { origin.x + COLUMN_WIDTH * c, origin.y};
+	NSPoint columnOrigin = { origin.x + COLUMN_WIDTH * p, origin.y};
 
 	NSRect oval = { columnOrigin.x - 5, columnOrigin.y + r.size.height * 0.5 - 5, 10, 10};
 
@@ -134,9 +134,9 @@ const BOOL SHUFFLE_COLORS = NO;
 	if (ENABLE_SHADOW && false) {
 		[NSGraphicsContext saveGraphicsState];
 		[[[self class] shadow] set];
-		[[NSColor blackColor] set];
 	}
-	[[NSColor blackColor] set];
+	NSArray* colors = [PBGitRevisionCell laneColors];
+	[(NSColor*)[colors objectAtIndex: (c % [colors count])] set];
 	[path fill];
 	if (ENABLE_SHADOW && false) {
 		[NSGraphicsContext restoreGraphicsState];
@@ -155,17 +155,17 @@ const BOOL SHUFFLE_COLORS = NO;
 
 }
 
-- (void) drawTriangleInRect: (NSRect) r sign: (char) sign
+- (void) drawTriangleInRect: (NSRect) r sign: (char) sign color: (int) c
 {
-	int c = cellInfo.position;
+	int p = cellInfo.position;
 	int columnHeight = 10;
 	int columnWidth = 8;
 
 	NSPoint top;
 	if (sign == '<')
-		top.x = round(r.origin.x) + 10 * c + 4;
+		top.x = round(r.origin.x) + 10 * p + 4;
 	else {
-		top.x = round(r.origin.x) + 10 * c - 4;
+		top.x = round(r.origin.x) + 10 * p - 4;
 		columnWidth *= -1;
 	}
 	top.y = r.origin.y + (r.size.height - columnHeight) / 2;
@@ -182,7 +182,8 @@ const BOOL SHUFFLE_COLORS = NO;
 
 	[[NSColor whiteColor] set];
 	[path fill];
-	[[NSColor blackColor] set];
+	NSArray* colors = [PBGitRevisionCell laneColors];
+	[(NSColor*)[colors objectAtIndex: (c % [colors count])] set];
 	[path setLineWidth: 2];
 	[path stroke];
 }
@@ -310,19 +311,22 @@ const BOOL SHUFFLE_COLORS = NO;
 		NSRect ownRect;
 		NSDivideRect(rect, &ownRect, &rect, pathWidth, NSMinXEdge);
 
-		int i;
+		int i, cellColorIndex = 0;
 		struct PBGitGraphLine *lines = cellInfo.lines;
 		for (i = 0; i < cellInfo.nLines; i++) {
+			int colorIndex = lines[i].colorIndex;
+			if (lines[i].from == cellInfo.position && lines[i].to == cellInfo.position)
+				cellColorIndex = colorIndex;
 			if (lines[i].upper == 0)
-				[self drawLineFromColumn: lines[i].from toColumn: lines[i].to inRect:ownRect offset: ownRect.size.height color: lines[i].colorIndex];
+				[self drawLineFromColumn: lines[i].from toColumn: lines[i].to inRect:ownRect offset: ownRect.size.height color: colorIndex];
 			else
-				[self drawLineFromColumn: lines[i].from toColumn: lines[i].to inRect:ownRect offset: 0 color:lines[i].colorIndex];
+				[self drawLineFromColumn: lines[i].from toColumn: lines[i].to inRect:ownRect offset: 0 color: colorIndex];
 		}
 
 		if (cellInfo.sign == '<' || cellInfo.sign == '>')
-			[self drawTriangleInRect: ownRect sign: cellInfo.sign];
+			[self drawTriangleInRect: ownRect sign: cellInfo.sign color: cellColorIndex];
 		else
-			[self drawCircleInRect: ownRect];
+			[self drawCircleInRect: ownRect color: cellColorIndex];
 	}
 
 

--- a/Classes/Views/PBGitRevisionCell.m
+++ b/Classes/Views/PBGitRevisionCell.m
@@ -29,15 +29,31 @@ const BOOL SHUFFLE_COLORS = NO;
 	return self;
 }
 
+#define HEX_COLOR(hex)                        \
+{                                             \
+	(CGFloat)((((hex) >> 16) & 0xFF) / 255.0f), \
+	(CGFloat)((((hex) >> 8)  & 0xFF) / 255.0f), \
+	(CGFloat)((((hex) >> 0)  & 0xFF) / 255.0f)  \
+}
+
 + (NSArray *)laneColors
 {
-	static const size_t colorCount = 8;
+	static const CGFloat colorPalette[][3] = {
+		HEX_COLOR(0xF00000), // red
+		HEX_COLOR(0xFF8000), // tangerine (orange)
+		HEX_COLOR(0xE0D030), // yellow
+		HEX_COLOR(0x008000), // clover (green)
+		HEX_COLOR(0x00D0D0), // cyan
+		HEX_COLOR(0x0000FF), // blueberry (navy)
+		HEX_COLOR(0x0080FF), // aqua (sky blue)
+		HEX_COLOR(0x8000FF), // grape (violet)
+		HEX_COLOR(0xFF00FF), // magenta
+	};
 	static NSArray *laneColors = nil;
 	if (!laneColors) {
-		float segment = 1.0f / colorCount;
 		NSMutableArray *colors = [NSMutableArray new];
-		for (size_t i = 0; i < colorCount; ++i) {
-			NSColor *newColor = [NSColor colorWithCalibratedHue:(segment * i) saturation:0.9f brightness:0.9f alpha:1.0f];
+		for (size_t i = 0; i < sizeof(colorPalette)/sizeof(*colorPalette); ++i) {
+			NSColor *newColor = [NSColor colorWithCalibratedRed:colorPalette[i][0] green:colorPalette[i][1] blue:colorPalette[i][2] alpha:1.0f];
 			[colors addObject:newColor];
 		}
 		if (SHUFFLE_COLORS) {

--- a/Classes/Views/PBGitRevisionCell.m
+++ b/Classes/Views/PBGitRevisionCell.m
@@ -194,11 +194,8 @@ const BOOL SHUFFLE_COLORS = NO;
 	
 	[style setAlignment:NSCenterTextAlignment];
 	[attributes setObject:style forKey:NSParagraphStyleAttributeName];
-	[attributes setObject:[NSFont fontWithName:@"LucidaGrande" size:10] forKey:NSFontAttributeName];
-
-	if (selected && false) { // white text is a bit too hard to read (even with shadow) on refs
-		[attributes setObject:[NSColor alternateSelectedControlTextColor] forKey:NSForegroundColorAttributeName];
-	}
+	[attributes setObject:[NSFont boldSystemFontOfSize:9] forKey:NSFontAttributeName];
+	[attributes setObject:[NSColor colorWithWhite:0 alpha:.6] forKey:NSForegroundColorAttributeName];
 
 	if (ENABLE_SHADOW) {
 		attributes[NSShadowAttributeName] = [[self class] textInsetShadow];
@@ -244,8 +241,8 @@ const BOOL SHUFFLE_COLORS = NO;
 		
 		NSRect newRect = lastRect;
 		newRect.size.width = textSize.width + ref_padding;
-		newRect.size.height = textSize.height;
-		newRect.origin.y = rect.origin.y + (rect.size.height - newRect.size.height) / 2;
+		newRect.size.height = textSize.height + 1;
+		newRect.origin.y = ceil(rect.origin.y + (rect.size.height - newRect.size.height) / 2);
 		
 		if (NSContainsRect(rect, newRect)) {
 			[array addObject:[NSValue valueWithRect:newRect]];

--- a/html/views/history/history.css
+++ b/html/views/history/history.css
@@ -158,9 +158,11 @@ a.showdiff {
 
 .refs {
 	font-size: 9px;
-	font-family: Helvetica;
+	font-family: ".Lucida Grande UI", "Lucida Grande", sans-serif;
+	font-weight: bold;
+	color: rgba(0,0,0,.7);;
 	margin-right: 2px;
-	padding: 1px 3px 1px 3px;
+	padding: 2px 3px;
 	-webkit-border-radius: 3px;
 	/*-webkit-box-shadow: 1px 1px 2px #444;*/
 }

--- a/html/views/history/history.css
+++ b/html/views/history/history.css
@@ -162,7 +162,7 @@ a.showdiff {
 	margin-right: 2px;
 	padding: 1px 3px 1px 3px;
 	-webkit-border-radius: 3px;
-	-webkit-box-shadow: 1px 1px 2px #444;
+	/*-webkit-box-shadow: 1px 1px 2px #444;*/
 }
 
 .refs.head {


### PR DESCRIPTION
Actually I think shadowless history looks great! Thanks for having compile time option for that, but I think you should consider shadowless as default.

Here's how it look here together with PDF icons (see my other merge).

![shadowless labels](https://f.cloud.github.com/assets/103067/2055118/51bcb732-8ac0-11e3-9a46-bcffb6815bef.png)
