### PR TITLE
Work on `gitx`

### DIFF
--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -7,6 +7,7 @@
 //
 
 #import "ApplicationController.h"
+#import "PBRepositoryDocumentController.h"
 #import "PBGitRevisionCell.h"
 #import "PBGitWindowController.h"
 #import "PBServicesController.h"
@@ -65,6 +66,20 @@ static OpenRecentController* recentsDialog = nil;
 		NSUpdateDynamicServices();
 		[[NSUserDefaults standardUserDefaults] setInteger:2 forKey:@"Services Version"];
 	}
+}
+
+- (BOOL)application:(NSApplication *)sender openFile:(NSString *)filename {
+    NSURL *repository = [NSURL fileURLWithPath:filename];
+    NSError *error = nil;
+    NSDocument *doc = [[PBRepositoryDocumentController sharedDocumentController] openDocumentWithContentsOfURL:repository
+                                                                                                       display:YES
+                                                                                                         error:&error];
+    if (!doc) {
+        NSLog(@"Error opening repository \"%@\": %@", repository.path, error);
+        return NO;
+    }
+
+    return YES;
 }
 
 - (BOOL)applicationShouldOpenUntitledFile:(NSApplication *)sender

--- a/Classes/Controllers/PBRepositoryDocumentController.m
+++ b/Classes/Controllers/PBRepositoryDocumentController.m
@@ -11,7 +11,6 @@
 #import "PBGitRevList.h"
 #import "PBEasyPipe.h"
 #import "PBGitBinary.h"
-#import "GitRepoFinder.h"
 
 #import <ObjectiveGit/GTRepository.h>
 

--- a/Classes/Util/PBEasyPipe.m
+++ b/Classes/Util/PBEasyPipe.m
@@ -93,8 +93,14 @@
 		[inHandle writeData:[input dataUsingEncoding:NSUTF8StringEncoding]];
 		[inHandle closeFile];
 	}
-	
-	[task launch];
+
+    @try {
+        [task launch];
+    }
+    @catch (NSException *exception) {
+        if (ret) *ret = -1;
+        return nil;
+    }
 	
 	NSData* data = [handle readDataToEndOfFile];
 	NSString *string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -149,21 +149,17 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 // if the repository is already open then this is also a good place to catch the event as the window is about to be brought forward
 - (void)showWindows
 {
-	NSAppleEventDescriptor *currentAppleEvent = [[NSAppleEventManager sharedAppleEventManager] currentAppleEvent];
+	NSScriptCommand *command = [NSScriptCommand currentCommand];
 
-	if (currentAppleEvent) {
-		NSAppleEventDescriptor *eventRecord = [currentAppleEvent paramDescriptorForKeyword:keyAEPropData];
+	if (command) {
+		NSURL *repoURL = [command directParameter];
 
 		// on app launch there may be many repositories opening, so double check that this is the right repo
-		NSString *path = [[eventRecord paramDescriptorForKeyword:typeFileURL] stringValue];
-		if (path) {
-			NSURL *workingDirectory = [NSURL URLWithString:path];
-			if ([[PBRepositoryFinder gitDirForURL:workingDirectory] isEqual:[self fileURL]]) {
-				NSAppleEventDescriptor *argumentsList = [eventRecord paramDescriptorForKeyword:kGitXAEKeyArgumentsList];
-				[self handleGitXScriptingArguments:argumentsList inWorkingDirectory:workingDirectory];
-
-				// showWindows may be called more than once during app launch so remove the CLI data after we handle the event
-				[currentAppleEvent removeDescriptorWithKeyword:keyAEPropData];
+		if (repoURL) {
+			repoURL = [PBRepositoryFinder gitDirForURL:repoURL];
+			if ([repoURL isEqual:self.gitURL]) {
+				NSArray *arguments = command.arguments[@"openOptions"];
+				[self handleGitXScriptingArguments:arguments];
 			}
 		}
 	}
@@ -951,7 +947,7 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 
 #pragma mark GitX Scripting
 
-- (void)handleRevListArguments:(NSArray *)arguments inWorkingDirectory:(NSURL *)workingDirectory
+- (void)handleRevListArguments:(NSArray *)arguments
 {
 	if (![arguments count])
 		return;
@@ -963,13 +959,13 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 		PBGitRef *refArgument = [self refForName:[arguments lastObject]];
 		if (refArgument) {
 			revListSpecifier = [[PBGitRevSpecifier alloc] initWithRef:refArgument];
-			revListSpecifier.workingDirectory = workingDirectory;
+			revListSpecifier.workingDirectory = self.workingDirectoryURL;
 		}
 	}
 
 	if (!revListSpecifier) {
 		revListSpecifier = [[PBGitRevSpecifier alloc] initWithParameters:arguments];
-		revListSpecifier.workingDirectory = workingDirectory;
+		revListSpecifier.workingDirectory = self.workingDirectoryURL;
 	}
 
 	self.currentBranch = [self addBranch:revListSpecifier];
@@ -977,7 +973,7 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 	[self.windowController showHistoryView:self];
 }
 
-- (void)handleBranchFilterEventForFilter:(PBGitXBranchFilterType)filter additionalArguments:(NSMutableArray *)arguments inWorkingDirectory:(NSURL *)workingDirectory
+- (void)handleBranchFilterEventForFilter:(PBGitXBranchFilterType)filter additionalArguments:(NSArray *)arguments
 {
 	self.currentBranchFilter = filter;
 	[PBGitDefaults setShowStageView:NO];
@@ -985,23 +981,13 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 
 	// treat any additional arguments as a rev-list specifier
 	if ([arguments count] > 1) {
-		[arguments removeObjectAtIndex:0];
-		[self handleRevListArguments:arguments inWorkingDirectory:workingDirectory];
+		arguments = [arguments subarrayWithRange:NSMakeRange(1, arguments.count)];
+		[self handleRevListArguments:arguments];
 	}
 }
 
-- (void)handleGitXScriptingArguments:(NSAppleEventDescriptor *)argumentsList inWorkingDirectory:(NSURL *)workingDirectory
+- (void)handleGitXScriptingArguments:(NSArray *)arguments
 {
-	NSMutableArray *arguments = [NSMutableArray array];
-	uint argumentsIndex = 1; // AppleEvent list descriptor's are one based
-	while(1) {
-		NSAppleEventDescriptor *arg = [argumentsList descriptorAtIndex:argumentsIndex++];
-		if (arg)
-			[arguments addObject:[arg stringValue]];
-		else
-			break;
-	}
-
 	if (![arguments count])
 		return;
 
@@ -1014,22 +1000,22 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 	}
 
 	if ([firstArgument isEqualToString:@"--all"]) {
-		[self handleBranchFilterEventForFilter:kGitXAllBranchesFilter additionalArguments:arguments inWorkingDirectory:workingDirectory];
+		[self handleBranchFilterEventForFilter:kGitXAllBranchesFilter additionalArguments:arguments];
 		return;
 	}
 
 	if ([firstArgument isEqualToString:@"--local"]) {
-		[self handleBranchFilterEventForFilter:kGitXLocalRemoteBranchesFilter additionalArguments:arguments inWorkingDirectory:workingDirectory];
+		[self handleBranchFilterEventForFilter:kGitXLocalRemoteBranchesFilter additionalArguments:arguments];
 		return;
 	}
 
 	if ([firstArgument isEqualToString:@"--branch"]) {
-		[self handleBranchFilterEventForFilter:kGitXSelectedBranchFilter additionalArguments:arguments inWorkingDirectory:workingDirectory];
+		[self handleBranchFilterEventForFilter:kGitXSelectedBranchFilter additionalArguments:arguments];
 		return;
 	}
 
 	// if the argument is not a known command then treat it as a rev-list specifier
-	[self handleRevListArguments:arguments inWorkingDirectory:workingDirectory];
+	[self handleRevListArguments:arguments];
 }
 
 // for the scripting bridge

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -21,7 +21,8 @@
 #import "GitXScriptingConstants.h"
 #import "PBHistorySearchController.h"
 #import "PBGitRepositoryWatcher.h"
-#import "GitRepoFinder.h"
+#import "PBRepositoryFinder.h"
+#import "PBGitSubmodule.h"
 #import "PBGitHistoryList.h"
 
 
@@ -157,7 +158,7 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 		NSString *path = [[eventRecord paramDescriptorForKeyword:typeFileURL] stringValue];
 		if (path) {
 			NSURL *workingDirectory = [NSURL URLWithString:path];
-			if ([[GitRepoFinder gitDirForURL:workingDirectory] isEqual:[self fileURL]]) {
+			if ([[PBRepositoryFinder gitDirForURL:workingDirectory] isEqual:[self fileURL]]) {
 				NSAppleEventDescriptor *argumentsList = [eventRecord paramDescriptorForKeyword:kGitXAEKeyArgumentsList];
 				[self handleGitXScriptingArguments:argumentsList inWorkingDirectory:workingDirectory];
 

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -216,6 +216,15 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
     return self.gtRepo.gitDirectoryURL;
 }
 
+- (NSURL *)workingDirectoryURL {
+    return self.gtRepo.fileURL;
+}
+
+- (NSString *)workingDirectory
+{
+    return self.workingDirectoryURL.path;
+}
+
 - (void)forceUpdateRevisions
 {
 	[revisionList forceUpdate];
@@ -565,20 +574,6 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 - (void) readCurrentBranch
 {
 		self.currentBranch = [self addBranch: [self headRef]];
-}
-
-- (NSString *) workingDirectory
-{
-	const char* workdir = git_repository_workdir(self.gtRepo.git_repository);
-	if (workdir)
-	{
-		NSString* result = [[NSString stringWithUTF8String:workdir] stringByStandardizingPath];
-		return result;
-	}
-    else
-	{
-        return self.fileURL.path;
-	}
 }
 
 #pragma mark Remotes

--- a/Classes/git/PBRepositoryFinder.h
+++ b/Classes/git/PBRepositoryFinder.h
@@ -1,5 +1,5 @@
 //
-//  GitRepoFinder.h
+//  PBRepositoryFinder.h
 //  GitX
 //
 //  Created by Rowan James on 13/11/2012.
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface GitRepoFinder : NSObject
+@interface PBRepositoryFinder : NSObject
 
 + (NSURL*)workDirForURL:(NSURL*)fileURL;
 + (NSURL*)gitDirForURL:(NSURL*)fileURL;

--- a/Classes/git/PBRepositoryFinder.m
+++ b/Classes/git/PBRepositoryFinder.m
@@ -1,0 +1,83 @@
+//
+//  PBRepositoryFinder.m
+//  GitX
+//
+//  Created by Rowan James on 13/11/2012.
+//
+//
+
+#import "PBRepositoryFinder.h"
+
+@implementation PBRepositoryFinder
+
++ (NSURL *)workDirForURL:(NSURL *)fileURL;
+{
+  if (!fileURL.isFileURL) {
+    return nil;
+  }
+
+  git_repository *repo = NULL;
+  git_repository_open_ext(&repo, fileURL.path.UTF8String, GIT_REPOSITORY_OPEN_CROSS_FS, NULL);
+  if (!repo) {
+    return NULL;
+  }
+
+  const char *workdir = git_repository_workdir(repo);
+  NSURL *result = nil;
+  if (workdir) {
+    result = [NSURL fileURLWithPath:[NSString stringWithUTF8String:workdir]];
+  }
+
+  git_repository_free(repo); repo = nil;
+  return result;
+}
+
++ (NSURL *)gitDirForURL:(NSURL *)fileURL
+{
+  if (!fileURL.isFileURL)
+  {
+    return nil;
+  }
+  git_buf path_buffer = {NULL, 0, 0};
+  int gitResult = git_repository_discover(&path_buffer,
+                                          [fileURL.path UTF8String],
+                                          GIT_REPOSITORY_OPEN_CROSS_FS,
+                                          nil);
+
+  NSData *repoPathBuffer = nil;
+  if (path_buffer.ptr) {
+    repoPathBuffer = [NSData dataWithBytes:path_buffer.ptr length:path_buffer.asize];
+    git_buf_free(&path_buffer);
+  }
+
+  if (gitResult == GIT_OK && repoPathBuffer.length)
+  {
+    NSString* repoPath = [NSString stringWithUTF8String:repoPathBuffer.bytes];
+    BOOL isDirectory;
+    if ([[NSFileManager defaultManager] fileExistsAtPath:repoPath
+                                             isDirectory:&isDirectory] && isDirectory)
+    {
+      NSURL* result = [NSURL fileURLWithPath:repoPath
+                                 isDirectory:isDirectory];
+      return result;
+    }
+  }
+  return nil;
+}
+
++ (NSURL *)fileURLForURL:(NSURL *)inputURL
+{
+  NSURL* gitDir = [self gitDirForURL:inputURL];
+  if (!gitDir) {
+    return nil; // not a Git directory at all
+  }
+
+  NSURL *workDir = [self workDirForURL:inputURL];
+  if (workDir) {
+    return workDir; // root of this working copy or deepest submodule
+  }
+
+  return gitDir; // bare repo
+}
+
+@end

--- a/Classes/gitx.m
+++ b/Classes/gitx.m
@@ -325,14 +325,6 @@ NSURL *workingDirectoryURL(NSMutableArray *arguments)
 
 }
 
-NSMutableArray *argumentsArray()
-{
-	NSMutableArray *arguments = [[[NSProcessInfo processInfo] arguments] mutableCopy];
-	[arguments removeObjectAtIndex:0]; // url to executable path is not needed
-
-	return arguments;
-}
-
 int main(int argc, const char** argv)
 {
 	@autoreleasepool {
@@ -352,9 +344,12 @@ int main(int argc, const char** argv)
 		// gitx can be used to pipe diff output to be displayed in GitX
 		if (!isatty(STDIN_FILENO) && fdopen(STDIN_FILENO, "r"))
 			handleSTDINDiff();
-		
+
+
+		NSMutableArray *arguments = [[[NSProcessInfo processInfo] arguments] mutableCopy];
+		[arguments removeObjectAtIndex:0]; // url to executable path is not needed
+
 		// From this point, we require a working directory and the arguments
-		NSMutableArray *arguments = argumentsArray();
 		NSURL *wdURL = workingDirectoryURL(arguments);
 		if (!wdURL)
 		{

--- a/Classes/gitx.m
+++ b/Classes/gitx.m
@@ -114,10 +114,10 @@ void handleDiffWithArguments(NSURL *repositoryURL, NSArray *arguments)
 	exit(0);
 }
 
-void handleOpenRepository(NSURL *repositoryURL, NSMutableArray *arguments)
+void handleOpenRepository(NSURL *repositoryURL, NSArray *arguments)
 {
     GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
-    [gitXApp open:repositoryURL];
+    [gitXApp open:repositoryURL withOptions:arguments];
     return;
 }
 

--- a/Classes/gitx.m
+++ b/Classes/gitx.m
@@ -116,35 +116,9 @@ void handleDiffWithArguments(NSURL *repositoryURL, NSArray *arguments)
 
 void handleOpenRepository(NSURL *repositoryURL, NSMutableArray *arguments)
 {
-	// if there are command line arguments send them to GitX through an Apple Event
-	// the recordDescriptor will be stored in keyAEPropData inside the openDocument or openApplication event
-	NSAppleEventDescriptor *recordDescriptor = nil;
-	if ([arguments count]) {
-		recordDescriptor = [NSAppleEventDescriptor recordDescriptor];
-
-		NSAppleEventDescriptor *listDescriptor = [NSAppleEventDescriptor listDescriptor];
-		uint listIndex = 1; // AppleEvent list descriptor's are one based
-		for (NSString *argument in arguments)
-			[listDescriptor insertDescriptor:[NSAppleEventDescriptor descriptorWithString:argument] atIndex:listIndex++];
-
-		[recordDescriptor setParamDescriptor:listDescriptor forKeyword:kGitXAEKeyArgumentsList];
-
-		// this is used as a double check in GitX
-		NSAppleEventDescriptor *url = [NSAppleEventDescriptor descriptorWithString:[repositoryURL absoluteString]];
-		[recordDescriptor setParamDescriptor:url forKeyword:typeFileURL];
-	}
-
-	// use NSWorkspace to open GitX and send the arguments
-	// this allows the repository document to modify itself before it shows it's GUI
-	BOOL didOpenURLs = [[NSWorkspace sharedWorkspace] openURLs:[NSArray arrayWithObject:repositoryURL]
-									   withAppBundleIdentifier:kGitXBundleIdentifier
-													   options:0
-								additionalEventParamDescriptor:recordDescriptor
-											 launchIdentifiers:NULL];
-	if (!didOpenURLs) {
-		printf("Unable to open GitX.app\n");
-		exit(2);
-	}
+    GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
+    [gitXApp open:repositoryURL];
+    return;
 }
 
 void handleInit(NSURL *repositoryURL)

--- a/Classes/gitx.m
+++ b/Classes/gitx.m
@@ -124,7 +124,7 @@ void handleOpenRepository(NSURL *repositoryURL, NSArray *arguments)
 void handleInit(NSURL *repositoryURL)
 {
 	GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
-	[gitXApp initRepository:repositoryURL];
+	[gitXApp createRepository:repositoryURL];
 
 	exit(0);
 }

--- a/Classes/gitx.m
+++ b/Classes/gitx.m
@@ -87,13 +87,8 @@ void usage(char const *programName)
 
 void version_info()
 {
-	NSString *version = [[[NSBundle bundleForClass:[PBGitBinary class]] infoDictionary] valueForKey:@"CFBundleVersion"];
-	NSString *gitVersion = [[[NSBundle bundleForClass:[PBGitBinary class]] infoDictionary] valueForKey:@"CFBundleGitVersion"];
-	printf("GitX version %s (%s)\n", [version UTF8String], [gitVersion UTF8String]);
-	if ([PBGitBinary path])
-		printf("Using git found at %s, version %s\n", [[PBGitBinary path] UTF8String], [[PBGitBinary version] UTF8String]);
-	else
-		printf("GitX cannot find a git binary\n");
+    NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey];
+	printf("GitX version %s\n", [version UTF8String]);
 	exit(1);
 }
 

--- a/GitX.entitlements
+++ b/GitX.entitlements
@@ -1,5 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>net.phere.gitx-cli</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+	<key>CFBundleVersion</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+</dict>
 </plist>

--- a/GitX.h
+++ b/GitX.h
@@ -8,6 +8,19 @@
 
 @class GitXApplication, GitXDocument, GitXWindow;
 
+enum GitXSaveOptions {
+	GitXSaveOptionsYes = 'yes ' /* Save the file. */,
+	GitXSaveOptionsNo = 'no  ' /* Do not save the file. */,
+	GitXSaveOptionsAsk = 'ask ' /* Ask the user whether or not to save the file. */
+};
+typedef enum GitXSaveOptions GitXSaveOptions;
+
+enum GitXPrintingErrorHandling {
+	GitXPrintingErrorHandlingStandard = 'lwst' /* Standard PostScript error handling */,
+	GitXPrintingErrorHandlingDetailed = 'lwdt' /* print a detailed report of PostScript errors */
+};
+typedef enum GitXPrintingErrorHandling GitXPrintingErrorHandling;
+
 
 
 /*
@@ -24,8 +37,9 @@
 @property (readonly) BOOL frontmost;  // Is this the active application?
 @property (copy, readonly) NSString *version;  // The version number of the application.
 
-- (void) open:(NSArray *)x;  // Open a document.
-- (void) quit;  // Quit the application.
+- (id) open:(id)x;  // Open a document.
+- (void) print:(id)x withProperties:(NSDictionary *)withProperties printDialog:(BOOL)printDialog;  // Print a document.
+- (void) quitSaving:(GitXSaveOptions)saving;  // Quit the application.
 - (BOOL) exists:(id)x;  // Verify that an object exists.
 - (void) showDiff:(NSString *)x;  // Show the supplied diff output in a GitX window.
 - (void) initRepository:(NSURL *)x NS_RETURNS_NOT_RETAINED;  // Create a git repository at the given filesystem URL.
@@ -37,9 +51,11 @@
 @interface GitXDocument : SBObject
 
 @property (copy, readonly) NSString *name;  // Its name.
+@property (readonly) BOOL modified;  // Has it been modified since the last save?
 @property (copy, readonly) NSURL *file;  // Its location on disk, if it has one.
 
-- (void) close;  // Close a document.
+- (void) closeSaving:(GitXSaveOptions)saving savingIn:(NSURL *)savingIn;  // Close a document.
+- (void) printWithProperties:(NSDictionary *)withProperties printDialog:(BOOL)printDialog;  // Print a document.
 - (void) delete;  // Delete an object.
 - (void) duplicateTo:(SBObject *)to withProperties:(NSDictionary *)withProperties;  // Copy an object.
 - (void) moveTo:(SBObject *)to;  // Move an object to a new location.
@@ -63,7 +79,8 @@
 @property BOOL zoomed;  // Is the window zoomed right now?
 @property (copy, readonly) GitXDocument *document;  // The document whose contents are displayed in the window.
 
-- (void) close;  // Close a document.
+- (void) closeSaving:(GitXSaveOptions)saving savingIn:(NSURL *)savingIn;  // Close a document.
+- (void) printWithProperties:(NSDictionary *)withProperties printDialog:(BOOL)printDialog;  // Print a document.
 - (void) delete;  // Delete an object.
 - (void) duplicateTo:(SBObject *)to withProperties:(NSDictionary *)withProperties;  // Copy an object.
 - (void) moveTo:(SBObject *)to;  // Move an object to a new location.

--- a/GitX.h
+++ b/GitX.h
@@ -42,6 +42,7 @@ typedef enum GitXPrintingErrorHandling GitXPrintingErrorHandling;
 - (void) quitSaving:(GitXSaveOptions)saving;  // Quit the application.
 - (BOOL) exists:(id)x;  // Verify that an object exists.
 - (void) showDiff:(NSString *)x;  // Show the supplied diff output in a GitX window.
+- (void) performDiffIn:(NSURL *)x withOptions:(NSArray *)withOptions;  // Perform a diff operation in a repository.
 - (void) initRepository:(NSURL *)x NS_RETURNS_NOT_RETAINED;  // Create a git repository at the given filesystem URL.
 - (void) cloneRepository:(NSString *)x to:(NSURL *)to isBare:(BOOL)isBare;  // Clone a repository.
 

--- a/GitX.h
+++ b/GitX.h
@@ -44,7 +44,7 @@ typedef enum GitXPrintingErrorHandling GitXPrintingErrorHandling;
 - (id) open:(id)x withOptions:(NSArray *)withOptions;  // Open a document.
 - (void) showDiff:(NSString *)x;  // Show the supplied diff output in a GitX window.
 - (void) performDiffIn:(NSURL *)x withOptions:(NSArray *)withOptions;  // Perform a diff operation in a repository.
-- (void) initRepository:(NSURL *)x NS_RETURNS_NOT_RETAINED;  // Create a git repository at the given filesystem URL.
+- (void) createRepository:(NSURL *)x;  // Create a git repository at the given filesystem URL.
 - (void) cloneRepository:(NSString *)x to:(NSURL *)to isBare:(BOOL)isBare;  // Clone a repository.
 
 @end

--- a/GitX.h
+++ b/GitX.h
@@ -41,6 +41,7 @@ typedef enum GitXPrintingErrorHandling GitXPrintingErrorHandling;
 - (void) print:(id)x withProperties:(NSDictionary *)withProperties printDialog:(BOOL)printDialog;  // Print a document.
 - (void) quitSaving:(GitXSaveOptions)saving;  // Quit the application.
 - (BOOL) exists:(id)x;  // Verify that an object exists.
+- (id) open:(id)x withOptions:(NSArray *)withOptions;  // Open a document.
 - (void) showDiff:(NSString *)x;  // Show the supplied diff output in a GitX window.
 - (void) performDiffIn:(NSURL *)x withOptions:(NSArray *)withOptions;  // Perform a diff operation in a repository.
 - (void) initRepository:(NSURL *)x NS_RETURNS_NOT_RETAINED;  // Create a git repository at the given filesystem URL.

--- a/GitX.sdef
+++ b/GitX.sdef
@@ -1,28 +1,117 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE dictionary SYSTEM "file://localhost/System/Library/DTDs/sdef.dtd">
 
-<dictionary title="GitX Terminology">
-
+<dictionary title="GitX Terminology" xmlns:xi="http://www.w3.org/2003/XInclude">
 	<suite name="Standard Suite" code="????" description="Common classes and commands for all applications.">
-
 		<command name="open" code="aevtodoc" description="Open a document.">
 			<direct-parameter description="The file(s) to be opened.">
+				<type type="file"/>
 				<type type="file" list="yes"/>
 			</direct-parameter>
+			<result description="The opened document(s).">
+				<type type="document"/>
+				<type type="document" list="yes"/>
+			</result>
 		</command>
+
+		<enumeration name="save options" code="savo">
+			<enumerator name="yes" code="yes " description="Save the file."/>
+			<enumerator name="no" code="no  " description="Do not save the file."/>
+			<enumerator name="ask" code="ask " description="Ask the user whether or not to save the file."/>
+		</enumeration>
 
 		<command name="close" code="coreclos" description="Close a document.">
 			<cocoa class="NSCloseCommand"/>
-			<direct-parameter type="specifier" description="the document(s) or window(s) to close."/>
+			<access-group identifier="*"/>
+			<direct-parameter type="specifier" requires-access="r" description="the document(s) or window(s) to close."/>
+			<parameter name="saving" code="savo" type="save options" optional="yes" description="Should changes be saved before closing?">
+				<cocoa key="SaveOptions"/>
+			</parameter>
+			<parameter name="saving in" code="kfil" type="file" optional="yes" description="The file in which to save the document, if so.">
+				<cocoa key="File"/>
+			</parameter>
+		</command>
+
+        <!-- Save doesn't make sense to us -->
+        <!--
+		<command name="save" code="coresave" description="Save a document.">
+			<access-group identifier="*"/>
+			<direct-parameter type="specifier" requires-access="r" description="The document(s) or window(s) to save."/>
+			<parameter name="in" code="kfil" type="file" optional="yes" description="The file in which to save the document.">
+				<cocoa key="File"/>
+			</parameter>
+			<parameter name="as" code="fltp" type="saveable file format" optional="yes" description="The file format to use.">
+				<cocoa key="FileType"/>
+			</parameter>
+		</command>
+        -->
+
+		<enumeration name="printing error handling" code="enum">
+			<enumerator name="standard" code="lwst" description="Standard PostScript error handling">
+				<cocoa boolean-value="NO"/>
+			</enumerator>
+			<enumerator name="detailed" code="lwdt" description="print a detailed report of PostScript errors">
+				<cocoa boolean-value="YES"/>
+			</enumerator>
+		</enumeration>
+
+		<record-type name="print settings" code="pset">
+			<property name="copies" code="lwcp" type="integer" description="the number of copies of a document to be printed">
+				<cocoa key="NSCopies"/>
+			</property>
+			<property name="collating" code="lwcl" type="boolean" description="Should printed copies be collated?">
+				<cocoa key="NSMustCollate"/>
+			</property>
+			<property name="starting page" code="lwfp" type="integer" description="the first page of the document to be printed">
+				<cocoa key="NSFirstPage"/>
+			</property>
+			<property name="ending page" code="lwlp" type="integer" description="the last page of the document to be printed">
+				<cocoa key="NSLastPage"/>
+			</property>
+			<property name="pages across" code="lwla" type="integer" description="number of logical pages laid across a physical page">
+				<cocoa key="NSPagesAcross"/>
+			</property>
+			<property name="pages down" code="lwld" type="integer" description="number of logical pages laid out down a physical page">
+				<cocoa key="NSPagesDown"/>
+			</property>
+			<property name="requested print time" code="lwqt" type="date" description="the time at which the desktop printer should print the document">
+				<cocoa key="NSPrintTime"/>
+			</property>
+			<property name="error handling" code="lweh" type="printing error handling" description="how errors are handled">
+				<cocoa key="NSDetailedErrorReporting"/>
+			</property>
+			<property name="fax number" code="faxn" type="text" description="for fax number">
+				<cocoa key="NSFaxNumber"/>
+			</property>
+			<property name="target printer" code="trpr" type="text" description="for target printer">
+				<cocoa key="NSPrinterName"/>
+			</property>
+		</record-type>
+
+		<command name="print" code="aevtpdoc" description="Print a document.">
+			<direct-parameter description="The file(s), document(s), or window(s) to be printed.">
+				<type type="file" list="yes"/>
+				<type type="specifier"/>
+			</direct-parameter>
+			<parameter name="with properties" code="prdt" type="print settings" optional="yes" description="The print settings to use.">
+				<cocoa key="PrintSettings"/>
+			</parameter>
+			<parameter name="print dialog" code="pdlg" type="boolean" optional="yes" description="Should the application show the print dialog?">
+				<cocoa key="ShowPrintDialog"/>
+			</parameter>
 		</command>
 
 		<command name="quit" code="aevtquit" description="Quit the application.">
 			<cocoa class="NSQuitCommand"/>
+			<parameter name="saving" code="savo" type="save options" optional="yes" description="Should changes be saved before quitting?">
+				<cocoa key="SaveOptions"/>
+			</parameter>
 		</command>
 
 		<command name="count" code="corecnte" description="Return the number of elements of a particular class within an object.">
 			<cocoa class="NSCountCommand"/>
-			<direct-parameter type="specifier" description="The objects to be counted."/>
+			<access-group identifier="*"/>
+			<direct-parameter type="specifier" requires-access="r" description="The objects to be counted."/>
 			<parameter name="each" code="kocl" type="type" optional="yes" description="The class of objects to be counted." hidden="yes">
 				<cocoa key="ObjectClass"/>
 			</parameter>
@@ -31,12 +120,14 @@
 
 		<command name="delete" code="coredelo" description="Delete an object.">
 			<cocoa class="NSDeleteCommand"/>
+			<access-group identifier="*"/>
 			<direct-parameter type="specifier" description="The object(s) to delete."/>
 		</command>
 
 		<command name="duplicate" code="coreclon" description="Copy an object.">
 			<cocoa class="NSCloneCommand"/>
-			<direct-parameter type="specifier" description="The object(s) to copy."/>
+			<access-group identifier="*"/>
+			<direct-parameter type="specifier" requires-access="r" description="The object(s) to copy."/>
 			<parameter name="to" code="insh" type="location specifier" description="The location for the new copy or copies." optional="yes">
 				<cocoa key="ToLocation"/>
 			</parameter>
@@ -47,12 +138,14 @@
 
 		<command name="exists" code="coredoex" description="Verify that an object exists.">
 			<cocoa class="NSExistsCommand"/>
-			<direct-parameter type="any" description="The object(s) to check."/>
+			<access-group identifier="*"/>
+			<direct-parameter type="any" requires-access="r" description="The object(s) to check."/>
 			<result type="boolean" description="Did the object(s) exist?"/>
 		</command>
 
 		<command name="make" code="corecrel" description="Create a new object.">
 			<cocoa class="NSCreateCommand"/>
+			<access-group identifier="*"/>
 			<parameter name="new" code="kocl" type="type" description="The class of the new object.">
 				<cocoa key="ObjectClass"/>
 			</parameter>
@@ -70,7 +163,8 @@
 
 		<command name="move" code="coremove" description="Move an object to a new location.">
 			<cocoa class="NSMoveCommand"/>
-			<direct-parameter type="specifier" description="The object(s) to move."/>
+			<access-group identifier="*"/>
+			<direct-parameter type="specifier" requires-access="r" description="The object(s) to move."/>
 			<parameter name="to" code="insh" type="location specifier" description="The new location for the object(s).">
 				<cocoa key="ToLocation"/>
 			</parameter>
@@ -89,10 +183,13 @@
 			<element type="window" access="r">
 				<cocoa key="orderedWindows"/>
 			</element>
-			<responds-to name="open">
+			<responds-to command="open">
 				<cocoa method="handleOpenScriptCommand:"/>
 			</responds-to>
-			<responds-to name="quit">
+			<responds-to command="print">
+				<cocoa method="handlePrintScriptCommand:"/>
+			</responds-to>
+			<responds-to command="quit">
 				<cocoa method="handleQuitScriptCommand:"/>
 			</responds-to>
 		</class>
@@ -102,11 +199,20 @@
 			<property name="name" code="pnam" type="text" access="r" description="Its name.">
 				<cocoa key="displayName"/>
 			</property>
+			<property name="modified" code="imod" type="boolean" access="r" description="Has it been modified since the last save?">
+				<cocoa key="isDocumentEdited"/>
+			</property>
 			<property name="file" code="file" type="file" access="r" description="Its location on disk, if it has one.">
 				<cocoa key="fileURL"/>
 			</property>
 			<responds-to command="close">
 				<cocoa method="handleCloseScriptCommand:"/>
+			</responds-to>
+			<responds-to command="print">
+				<cocoa method="handlePrintScriptCommand:"/>
+			</responds-to>
+			<responds-to command="save">
+				<cocoa method="handleSaveScriptCommand:"/>
 			</responds-to>
 		</class>
 
@@ -145,14 +251,17 @@
 			<property name="zoomed" code="pzum" type="boolean" description="Is the window zoomed right now?">
 				<cocoa key="isZoomed"/>
 			</property>
-
 			<property name="document" code="docu" type="document" access="r" description="The document whose contents are displayed in the window."/>
-
-			<responds-to name="close">
+			<responds-to command="close">
 				<cocoa method="handleCloseScriptCommand:"/>
 			</responds-to>
+			<responds-to command="print">
+				<cocoa method="handlePrintScriptCommand:"/>
+			</responds-to>
+			<responds-to command="save">
+				<cocoa method="handleSaveScriptCommand:"/>
+			</responds-to>
 		</class>
-
 	</suite>
 
 	<suite name="GitX Suite" code="GitX" description="Classes for GitX.">

--- a/GitX.sdef
+++ b/GitX.sdef
@@ -265,6 +265,22 @@
 	</suite>
 
 	<suite name="GitX Suite" code="GitX" description="Classes for GitX.">
+        <!-- Override for the core open command: we handle options -->
+		<command name="open" code="aevtodoc" description="Open a document.">
+			<direct-parameter description="The file(s) to be opened.">
+				<type type="file"/>
+				<type type="file" list="yes"/>
+			</direct-parameter>
+            <parameter name="with options" code="PDOp" optional="yes" description="The options for the open operation.">
+                <type type="text" list="yes"/>
+                <cocoa key="openOptions"/>
+            </parameter>
+			<result description="The opened document(s).">
+				<type type="document"/>
+				<type type="document" list="yes"/>
+			</result>
+		</command>
+
 
 		<command name="show diff" code="GitXShDf" description="Show the supplied diff output in a GitX window.">
 			<direct-parameter type="text" description="The textual output from a diff tool."/>

--- a/GitX.sdef
+++ b/GitX.sdef
@@ -269,9 +269,19 @@
 		<command name="show diff" code="GitXShDf" description="Show the supplied diff output in a GitX window.">
 			<direct-parameter type="text" description="The textual output from a diff tool."/>
 		</command>
+
+		<command name="perform diff in" code="GitXPfDf" description="Perform a diff operation in a repository.">
+			<direct-parameter type="file" description="The repository to perform the diff in."/>
+            <parameter name="with options" code="PDOp" optional="yes" description="The options for the diff operation.">
+                <type type="text" list="yes"/>
+                <cocoa key="diffOptions"/>
+            </parameter>
+        </command>
+
 		<command name="init repository" code="GitXInit" description="Create a git repository at the given filesystem URL.">
 			<direct-parameter type="file" description="The URL of the repository to clone."/>
 		</command>
+
 		<command name="clone repository" code="GitXClon" description="Clone a repository.">
 			<direct-parameter type="text" description="The URL of the repository to clone."/>
 			<parameter name="to" code="URL " type="file" description="The location for the new repository.">
@@ -295,6 +305,9 @@
 		<class-extension extends="application" description="The GitX application.">
 			<responds-to name="show diff">
 				<cocoa method="showDiffScriptCommand:"/>
+			</responds-to>
+            <responds-to name="perform diff in">
+				<cocoa method="performDiffScriptCommand:"/>
 			</responds-to>
 			<responds-to name="init repository">
 				<cocoa method="initRepositoryScriptCommand:"/>

--- a/GitX.sdef
+++ b/GitX.sdef
@@ -294,8 +294,10 @@
             </parameter>
         </command>
 
-		<command name="init repository" code="GitXInit" description="Create a git repository at the given filesystem URL.">
-			<direct-parameter type="file" description="The URL of the repository to clone."/>
+        <!-- FIXME using "init" here causes sdf to put NS_RETURNS_NOT_RETAINED on the corresponding method (and triggers a warning) -->
+		<command name="create repository" code="GitXInit" description="Create a git repository at the given filesystem URL.">
+            <synonym name="init repository" code="GitXCrea" hidden="yes"/>
+			<direct-parameter type="file" description="The path where the repository should be created."/>
 		</command>
 
 		<command name="clone repository" code="GitXClon" description="Clone a repository.">

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		4D3F252B18C37D2E000922D9 /* Generate Scripting Header */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 4D3F252C18C37D2E000922D9 /* Build configuration list for PBXAggregateTarget "Generate Scripting Header" */;
+			buildPhases = (
+				4D3F252F18C37D5A000922D9 /* Generate Scripting Header */,
+			);
+			dependencies = (
+			);
+			name = "Generate Scripting Header";
+			productName = "Generate Scripting Header";
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		0A6858C711F7EA8A00AC2BE4 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A6858C611F7EA8A00AC2BE4 /* CoreServices.framework */; };
 		2682AABB1929140E00271A4D /* GTOID+JavaScript.m in Sources */ = {isa = PBXBuildFile; fileRef = 2682AABA1929140E00271A4D /* GTOID+JavaScript.m */; };
@@ -278,6 +292,20 @@
 			proxyType = 2;
 			remoteGlobalIDString = 88F05A6B16011E5400B7AD1D;
 			remoteInfo = ObjectiveGitTests;
+		};
+		4D3F253018C37D9A000922D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4D3F252B18C37D2E000922D9;
+			remoteInfo = "Generate Scripting Header";
+		};
+		4D3F253218C37D9F000922D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4D3F252B18C37D2E000922D9;
+			remoteInfo = "Generate Scripting Header";
 		};
 		551BF174112F3F3500265053 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1051,11 +1079,11 @@
 				8D11072E0486CEB800E47090 /* Frameworks */,
 				F580E6BD0E73329C009E2D3F /* CopyFiles */,
 				F5CF04A20EAE696C00D75C81 /* Copy HTML files */,
-				D81E15ED121CE83D00269E61 /* Scripting Bridge Header Script  */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				4D3F253118C37D9A000922D9 /* PBXTargetDependency */,
 				4A8F6B4A14A9B6B80002F4D7 /* PBXTargetDependency */,
 				4A68AD7114A00534006DE321 /* PBXTargetDependency */,
 				4A68AD7314A00534006DE321 /* PBXTargetDependency */,
@@ -1078,6 +1106,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				4D3F253318C37D9F000922D9 /* PBXTargetDependency */,
 				4A467EF01546D1F300F8902B /* PBXTargetDependency */,
 			);
 			name = "cli tool";
@@ -1124,6 +1153,7 @@
 				8D1107260486CEB800E47090 /* GitX */,
 				913D5E480E55644600CECEA2 /* cli tool */,
 				551BF110112F371800265053 /* gitx_askpasswd */,
+				4D3F252B18C37D2E000922D9 /* Generate Scripting Header */,
 			);
 		};
 /* End PBXProject section */
@@ -1260,7 +1290,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		D81E15ED121CE83D00269E61 /* Scripting Bridge Header Script  */ = {
+		4D3F252F18C37D5A000922D9 /* Generate Scripting Header */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1268,14 +1298,13 @@
 			inputPaths = (
 				"$(SRCROOT)/GitX.sdef",
 			);
-			name = "Scripting Bridge Header Script ";
+			name = "Generate Scripting Header";
 			outputPaths = (
 				"$(SRCROOT)/GitX.h",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Build the scripting bridge header GitX.h if the GitX.sdef file changes\necho \"Trying to build scripting definitions from $CONFIGURATION_BUILD_DIR/GitX.app\"\nif [ -e \"$CONFIGURATION_BUILD_DIR/GitX.app\" ]; then\n\techo -n \"generating...\"\n\tsdef \"$CONFIGURATION_BUILD_DIR/GitX.app\" | sdp -fh --basename GitX\n\techo \" done.\"\nelse\n\techo \"warning: Scripting definitions weren't generated.\"\nfi";
-			showEnvVarsInLog = 0;
+			shellScript = "# Build the scripting bridge header GitX.h if the GitX.sdef file changes\nsdp -fh --basename GitX $SRCROOT/GitX.sdef\n";
 		};
 		F5CF04A20EAE696C00D75C81 /* Copy HTML files */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1438,6 +1467,16 @@
 			isa = PBXTargetDependency;
 			name = MGScopeBar.framework;
 			targetProxy = 4A8F6B4914A9B6B80002F4D7 /* PBXContainerItemProxy */;
+		};
+		4D3F253118C37D9A000922D9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4D3F252B18C37D2E000922D9 /* Generate Scripting Header */;
+			targetProxy = 4D3F253018C37D9A000922D9 /* PBXContainerItemProxy */;
+		};
+		4D3F253318C37D9F000922D9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4D3F252B18C37D2E000922D9 /* Generate Scripting Header */;
+			targetProxy = 4D3F253218C37D9F000922D9 /* PBXContainerItemProxy */;
 		};
 		551BF175112F3F3500265053 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1607,6 +1646,20 @@
 			};
 			name = Release;
 		};
+		4D3F252D18C37D2E000922D9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		4D3F252E18C37D2E000922D9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		551BF113112F371800265053 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1676,6 +1729,15 @@
 			buildConfigurations = (
 				26FC0A890875C7B200E6366F /* Debug */,
 				26FC0A8A0875C7B200E6366F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4D3F252C18C37D2E000922D9 /* Build configuration list for PBXAggregateTarget "Generate Scripting Header" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4D3F252D18C37D2E000922D9 /* Debug */,
+				4D3F252E18C37D2E000922D9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -150,8 +150,8 @@
 		4A8F6B4C14A9B6C90002F4D7 /* MGScopeBar.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A8F6B4714A9B6110002F4D7 /* MGScopeBar.framework */; };
 		4A90A73514A9D24300D0DA02 /* GitX.sdef in Resources */ = {isa = PBXBuildFile; fileRef = 4A90A73414A9D24300D0DA02 /* GitX.sdef */; };
 		4AAAFDDA14A010DD008FC9B5 /* Sparkle.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A68AD6714A0050F006DE321 /* Sparkle.framework */; };
-		4AB057E31652652000DE751D /* GitRepoFinder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB057E21652652000DE751D /* GitRepoFinder.m */; };
-		4AB057E41652652000DE751D /* GitRepoFinder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB057E21652652000DE751D /* GitRepoFinder.m */; };
+		4AB057E31652652000DE751D /* PBRepositoryFinder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB057E21652652000DE751D /* PBRepositoryFinder.m */; };
+		4AB057E41652652000DE751D /* PBRepositoryFinder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB057E21652652000DE751D /* PBRepositoryFinder.m */; };
 		4AB71FF814B7EDD400F1DFFC /* RJModalRepoSheet.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB71FF714B7EDD400F1DFFC /* RJModalRepoSheet.m */; };
 		4AC42F7D16BFBADA007CCA3A /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A40159814067B7A00DB9C07 /* AppKit.framework */; };
 		551BF176112F3F4B00265053 /* gitx_askpasswd in Resources */ = {isa = PBXBuildFile; fileRef = 551BF111112F371800265053 /* gitx_askpasswd */; };
@@ -559,8 +559,8 @@
 		4A90A72C14A9C12F00D0DA02 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = SOURCE_ROOT; };
 		4A90A73314A9D1E800D0DA02 /* GitX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitX.h; sourceTree = SOURCE_ROOT; };
 		4A90A73414A9D24300D0DA02 /* GitX.sdef */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = GitX.sdef; sourceTree = SOURCE_ROOT; };
-		4AB057E11652652000DE751D /* GitRepoFinder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitRepoFinder.h; sourceTree = "<group>"; };
-		4AB057E21652652000DE751D /* GitRepoFinder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitRepoFinder.m; sourceTree = "<group>"; };
+		4AB057E11652652000DE751D /* PBRepositoryFinder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBRepositoryFinder.h; sourceTree = "<group>"; };
+		4AB057E21652652000DE751D /* PBRepositoryFinder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBRepositoryFinder.m; sourceTree = "<group>"; usesTabs = 0; };
 		4AB71FF614B7EDD400F1DFFC /* RJModalRepoSheet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RJModalRepoSheet.h; sourceTree = "<group>"; };
 		4AB71FF714B7EDD400F1DFFC /* RJModalRepoSheet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RJModalRepoSheet.m; sourceTree = "<group>"; };
 		551BF111112F371800265053 /* gitx_askpasswd */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = gitx_askpasswd; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -933,8 +933,8 @@
 				4A5D768414A9A9CC00DF6C68 /* PBGitXProtocol.m */,
 				643952751603EF9B00BB7AFF /* PBGitSVSubmoduleItem.h */,
 				643952761603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m */,
-				4AB057E11652652000DE751D /* GitRepoFinder.h */,
-				4AB057E21652652000DE751D /* GitRepoFinder.m */,
+				4AB057E11652652000DE751D /* PBRepositoryFinder.h */,
+				4AB057E21652652000DE751D /* PBRepositoryFinder.m */,
 				2682AAB91929140E00271A4D /* GTOID+JavaScript.h */,
 				2682AABA1929140E00271A4D /* GTOID+JavaScript.m */,
 			);
@@ -1424,7 +1424,7 @@
 				4A5D777514A9AEB000DF6C68 /* PBSourceViewRemote.m in Sources */,
 				4AB71FF814B7EDD400F1DFFC /* RJModalRepoSheet.m in Sources */,
 				643952771603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m in Sources */,
-				4AB057E31652652000DE751D /* GitRepoFinder.m in Sources */,
+				4AB057E31652652000DE751D /* PBRepositoryFinder.m in Sources */,
 				4A2125A417C0C78A00B5B582 /* NSColor+RGB.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1436,7 +1436,7 @@
 				4A5D773A14A9A9F600DF6C68 /* gitx.m in Sources */,
 				4A5D773C14A9AA2F00DF6C68 /* PBGitBinary.m in Sources */,
 				4A5D773D14A9AA3700DF6C68 /* PBEasyPipe.m in Sources */,
-				4AB057E41652652000DE751D /* GitRepoFinder.m in Sources */,
+				4AB057E41652652000DE751D /* PBRepositoryFinder.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -139,8 +139,6 @@
 		4A5D773914A9A9CC00DF6C68 /* PBSourceViewItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D76DF14A9A9CC00DF6C68 /* PBSourceViewItem.m */; };
 		4A5D773A14A9A9F600DF6C68 /* gitx.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D768614A9A9CC00DF6C68 /* gitx.m */; };
 		4A5D773B14A9A9F900DF6C68 /* gitx_askpasswd_main.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D768714A9A9CC00DF6C68 /* gitx_askpasswd_main.m */; };
-		4A5D773C14A9AA2F00DF6C68 /* PBGitBinary.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D764F14A9A9CC00DF6C68 /* PBGitBinary.m */; };
-		4A5D773D14A9AA3700DF6C68 /* PBEasyPipe.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D76B214A9A9CC00DF6C68 /* PBEasyPipe.m */; };
 		4A5D777314A9AEB000DF6C68 /* PBSourceViewAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D776D14A9AEB000DF6C68 /* PBSourceViewAction.m */; };
 		4A5D777414A9AEB000DF6C68 /* PBSourceViewBadge.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D776F14A9AEB000DF6C68 /* PBSourceViewBadge.m */; };
 		4A5D777514A9AEB000DF6C68 /* PBSourceViewRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D777214A9AEB000DF6C68 /* PBSourceViewRemote.m */; };
@@ -1436,8 +1434,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A5D773A14A9A9F600DF6C68 /* gitx.m in Sources */,
-				4A5D773C14A9AA2F00DF6C68 /* PBGitBinary.m in Sources */,
-				4A5D773D14A9AA3700DF6C68 /* PBEasyPipe.m in Sources */,
 				4AB057E41652652000DE751D /* PBRepositoryFinder.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -563,6 +563,7 @@
 		4AB057E21652652000DE751D /* PBRepositoryFinder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBRepositoryFinder.m; sourceTree = "<group>"; usesTabs = 0; };
 		4AB71FF614B7EDD400F1DFFC /* RJModalRepoSheet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RJModalRepoSheet.h; sourceTree = "<group>"; };
 		4AB71FF714B7EDD400F1DFFC /* RJModalRepoSheet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RJModalRepoSheet.m; sourceTree = "<group>"; };
+		4DC1853818E6F93200E8DB8F /* Info-gitx.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-gitx.plist"; sourceTree = "<group>"; };
 		551BF111112F371800265053 /* gitx_askpasswd */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = gitx_askpasswd; sourceTree = BUILT_PRODUCTS_DIR; };
 		643952751603EF9B00BB7AFF /* PBGitSVSubmoduleItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGitSVSubmoduleItem.h; sourceTree = "<group>"; };
 		643952761603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGitSVSubmoduleItem.m; sourceTree = "<group>"; };
@@ -720,6 +721,7 @@
 				4A5D75B514A9A90500DF6C68 /* source.css */,
 				4A5D75B714A9A90500DF6C68 /* UpdateKey.pem */,
 				4A5D75B914A9A90500DF6C68 /* XIBs */,
+				4DC1853818E6F93200E8DB8F /* Info-gitx.plist */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -1692,8 +1694,10 @@
 		913D5E4B0E55644600CECEA2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = GitX_Prefix.pch;
+				INFOPLIST_FILE = "Resources/Info-gitx.plist";
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = gitx;
 				SKIP_INSTALL = YES;
@@ -1703,8 +1707,10 @@
 		913D5E4C0E55644600CECEA2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = GitX_Prefix.pch;
+				INFOPLIST_FILE = "Resources/Info-gitx.plist";
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = gitx;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
This is based on #301.

Modifications :
- Adds more AppleScript so we can ask the main application to perform actions on our behalf instead of calling `git`. This effectively removes the dependency on `git` ;-).
  Note that I _added_ a dependency on Objective-Git, so that `gitx` can warn execution outside of a working copy without distracting you by making GitX do it.
- Make the `gitx` argument parsing handle file-system paths.
  This allows one to call `gitx path/to/submodule`, or `gitx ..` and have the window open at the correct location (see #8352816 for caveats though).
- Adds an integrated Info.plist file to `gitx` so it doesn't rely on GitX for `--version`.
- Various bells and whistles.
