### PR TITLE
Add more path separator and fix avatar uri error

### DIFF
--- a/Classes/Controllers/PBGitSidebarController.m
+++ b/Classes/Controllers/PBGitSidebarController.m
@@ -171,7 +171,9 @@
 		return item;
 	}
 
-	NSArray *pathComponents = [[rev simpleRef] componentsSeparatedByString:@"/"];
+	NSString *str = [[[rev simpleRef] componentsSeparatedByString:@"/"] componentsJoinedByString:@"-"];
+	NSArray *pathComponents = [str componentsSeparatedByString:@"-"];
+
 	if ([pathComponents count] < 2)
 		[branches addChild:[PBSourceViewItem itemWithRevSpec:rev]];
 	else if ([[pathComponents objectAtIndex:1] isEqualToString:@"heads"])

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -132,7 +132,7 @@ var setGravatar = function(email, image) {
 	}
 
 	image.src = "http://www.gravatar.com/avatar/" +
-		hex_md5(email.toLowerCase().replace(/ /g, "")) + "?d=wavatar&s=60";
+		hex_md5(email.toLowerCase().replace(/ /g, "")) + "?r=r&s=60";
 }
 
 var selectCommit = function(a) {


### PR DESCRIPTION
- Add '-' like '/' as the path separator to avoid '/' confused the remote heads.
- Fix avatar uri error
