### PR TITLE
Threading fixes for minor UI glitches

### DIFF
--- a/Classes/git/PBGitGrapher.mm
+++ b/Classes/git/PBGitGrapher.mm
@@ -19,7 +19,9 @@
 using namespace std;
 typedef std::vector<PBGitLane *> LaneCollection;
 
-@interface PBGitGrapher ()
+@interface PBGitGrapher () {
+	int _laneIndex;
+}
 
 @property (nonatomic, strong) PBGraphCellInfo *previous;
 @property (nonatomic, assign) LaneCollection *pl;
@@ -37,8 +39,8 @@ typedef std::vector<PBGitLane *> LaneCollection;
 	}
 	
 	self.pl = new LaneCollection;
-
-	PBGitLane::resetColors();
+	_laneIndex = 0;
+	
 	return self;
 }
 
@@ -107,7 +109,7 @@ void add_line(struct PBGitGraphLine *lines, int *nLines, int upper, int from, in
 	// If we already did the first parent, don't do so again
 	if (!didFirst && nParents) {
 		git_oid parentOID = [(PBGitSHA*)[parents objectAtIndex:0] oid];
-		PBGitLane *newLane = new PBGitLane(&parentOID);
+		PBGitLane *newLane = new PBGitLane(_laneIndex++, &parentOID);
 		currentLanes->push_back(newLane);
 		newPos = currentLanes->size();
 		add_line(lines, &currentLine, 0, newPos, newPos, newLane->index());
@@ -138,7 +140,7 @@ void add_line(struct PBGitGraphLine *lines, int *nLines, int upper, int from, in
 		
 		// Really add this parent
 		addedParent = YES;
-		PBGitLane *newLane = new PBGitLane(&parentOID);
+		PBGitLane *newLane = new PBGitLane(_laneIndex++, &parentOID);
 		currentLanes->push_back(newLane);
 		add_line(lines, &currentLine, 0, currentLanes->size(), newPos, newLane->index());
 	}

--- a/Classes/git/PBGitLane.h
+++ b/Classes/git/PBGitLane.h
@@ -9,28 +9,19 @@
 #import <Cocoa/Cocoa.h>
 
 class PBGitLane {
-	static int s_colorIndex;
-
 	git_oid d_sha;
 	int d_index;
 
 public:
 
-	PBGitLane(git_oid *sha)
+	PBGitLane(int index, git_oid *sha) : d_index(index)
 	{
-		d_index = s_colorIndex++;
 		d_sha = *sha;
 	}
 
-	PBGitLane(NSString *sha)
+	PBGitLane(int index, NSString *sha) : d_index(index)
 	{
 		git_oid_fromstr(&d_sha, [sha UTF8String]);
-		d_index = s_colorIndex++;
-	}
-	
-	PBGitLane()
-	{
-		d_index = s_colorIndex++;
 	}
 	
 	bool isCommit(git_oid sha) const
@@ -46,6 +37,4 @@ public:
 	}
 	
 	int index() const;
-
-	static void resetColors();
 };

--- a/Classes/git/PBGitLane.mm
+++ b/Classes/git/PBGitLane.mm
@@ -7,22 +7,6 @@
 //
 
 #import "PBGitLane.h"
-//class PBGitLane {
-//	static int s_colorIndex;
-//	
-//	char d_sha[20];
-//	int d_index;
-//	
-//public:
-//	PBGitLane(NSString *sha);
-//	
-//	bool isCommit(NSString *sha) const;
-//	int index(); const;
-//	
-//	static resetColors();
-//};
-
-int PBGitLane::s_colorIndex = 0;
 
 int PBGitLane::index() const
 {
@@ -32,9 +16,4 @@ int PBGitLane::index() const
 void PBGitLane::setSha(git_oid sha)
 {
 	d_sha = sha;
-}
-
-void PBGitLane::resetColors()
-{
-	s_colorIndex = 0;
 }

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -755,6 +755,7 @@
 			);
 			name = GitTest;
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
This fixes a couple of visual issues due to threading when the history list gets loaded multiple times concurrently.
PBGitGrapher wasn't thread-safe (was holding internal static state) and PBGitRevList wasn't handling thread cancellation correctly.
