### PR TITLE
Only require commit message to be non-empty

### DIFF
--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -213,9 +213,8 @@
 
 - (void)amendCommit:(NSNotification *)notification
 {
-	// Replace commit message with the old one if it's less than 3 characters long.
-	// This is just a random number.
-	if ([[commitMessageView string] length] > 3)
+	// Replace commit message with the old one if it's empty.
+	if ([[commitMessageView string] length] > 0)
 		return;
 	
 	NSString *message = [[notification userInfo] objectForKey:@"message"];

--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -159,7 +159,7 @@
 	}		
 	
 	NSString *commitMessage = [commitMessageView string];
-	if ([commitMessage length] < 3) {
+	if ([commitMessage length] == 0) {
 		[[repository windowController] showMessageSheet:@"Commitmessage missing" infoText:@"Please enter a commit message before committing"];
 		return;
 	}


### PR DESCRIPTION
For some reason, GitX requires commit messages to contain at least 3 characters. Git doesn't do this.
