### PR TITLE
add links to top in history and file view

### DIFF
--- a/html/lib/diffHighlighter.js
+++ b/html/lib/diffHighlighter.js
@@ -55,6 +55,7 @@ var highlightDiff = function(diff, element, callbacks) {
 	var mode_change = false;
 	var old_mode = "";
 	var new_mode = "";
+    var linkToTop = "<div class=\"top-link\"><a href=\"#\">Top</a></div>";
 
 	var hunk_start_line_1 = -1;
 	var hunk_start_line_2 = -1;
@@ -115,7 +116,7 @@ var highlightDiff = function(diff, element, callbacks) {
 		}
 
 		if (diffContent != "" || binary)
-			finalContent += '</div>';
+			finalContent += '</div>' + linkToTop;
 
 		line1 = "";
 		line2 = "";

--- a/html/views/commit/commit.css
+++ b/html/views/commit/commit.css
@@ -124,3 +124,7 @@ table.diff {
 	margin: -5px;
 	padding-left: 20px;
 }
+
+.top-link {
+    display: none;
+}

--- a/html/views/history/history.css
+++ b/html/views/history/history.css
@@ -181,6 +181,13 @@ a.showdiff {
 	background-color: #fca64f;
 }
 
+.top-link {
+    text-align: right;
+    margin-right: 20px;
+    padding-bottom: 5px;
+    font-size: 90%;
+}
+
 /*
 div.button
 {


### PR DESCRIPTION
I find scrolling in the diff view of a commit (or even a long file view for a single file) to be a pain, so I added links back to the top of the view. (They are hidden when inspecting a single file while staging a commit).
