### PR TITLE
Fix bug: modified "git add"ed files potentially not listed on "Unstaged Changes" view

### DIFF
--- a/Classes/git/PBGitIndex.m
+++ b/Classes/git/PBGitIndex.m
@@ -608,7 +608,7 @@ NSString *PBGitIndexOperationFailed = @"PBGitIndexOperationFailed";
 			// Unstaged, untracked dictionary ("Other" files), and file
 			// is indicated as new (which would be untracked), so let's
 			// remove it
-			else if (!tracked && file.status == NEW)
+			else if (!tracked && file.status == NEW && file.commitBlobSHA == nil)
 				file.hasUnstagedChanges = NO;
 		}
 	}


### PR DESCRIPTION
How to reproduce the issue:
1. Create new git repository and add first commit for testing.
2. Open the test repository using GitX.
3. Create new file and `git add` it.
4. Edit the added file and save changes.
5. Move to "Commit" view with Command+2 on GitX, and refresh with Command+R.

then, the `git add`'ed modified file potentially not listed on "Unstaged Changes" view.
This problem occurs in about 0.5 of probability for every Command+R refresh.

To fix this issue, we have to update the condition in `PBGitIndex::addFilesFromDictionary` called from `PBGitIndex::readOtherFiles`, where the **STAGED** modified files unexpectedly marked as **NOT STAGED**.
