### PR TITLE
Allow dragging SHA from commit list as plain text

### DIFF
--- a/Classes/Controllers/PBRefController.m
+++ b/Classes/Controllers/PBRefController.m
@@ -339,29 +339,32 @@
 	NSPoint location = [(PBCommitList *)tv mouseDownPoint];
 	int row = [tv rowAtPoint:location];
 	int column = [tv columnAtPoint:location];
-	int subjectColumn = [tv columnWithIdentifier:@"SubjectColumn"];
-	if (column != subjectColumn)
-		return NO;
 	
 	PBGitRevisionCell *cell = (PBGitRevisionCell *)[tv preparedCellAtColumn:column row:row];
-	NSRect cellFrame = [tv frameOfCellAtColumn:column row:row];
-	
-	int index = [cell indexAtX:(location.x - cellFrame.origin.x)];
-	
-	if (index == -1)
-		return NO;
+	PBGitCommit *commit = [[commitController arrangedObjects] objectAtIndex:row];
 
-	PBGitRef *ref = [[[cell objectValue] refs] objectAtIndex:index];
-	if ([ref isTag] || [ref isRemoteBranch])
-		return NO;
+	int index = -1;
+	if ([cell respondsToSelector:@selector(indexAtX:)]) {
+		NSRect cellFrame = [tv frameOfCellAtColumn:column row:row];
+		index = [cell indexAtX:(location.x - cellFrame.origin.x)];
+	}
+	
+	if (index != -1) {
+		PBGitRef *ref = [[commit refs] objectAtIndex:index];
+		if ([ref isTag] || [ref isRemoteBranch])
+			return NO;
 
-	if ([[[historyController.repository headRef] ref] isEqualToRef:ref])
-		return NO;
-	
-	NSData *data = [NSKeyedArchiver archivedDataWithRootObject:[NSArray arrayWithObjects:[NSNumber numberWithInt:row], [NSNumber numberWithInt:index], NULL]];
-	[pboard declareTypes:[NSArray arrayWithObject:@"PBGitRef"] owner:self];
-	[pboard setData:data forType:@"PBGitRef"];
-	
+		if ([[[historyController.repository headRef] ref] isEqualToRef:ref])
+			return NO;
+
+		NSData *data = [NSKeyedArchiver archivedDataWithRootObject:[NSArray arrayWithObjects:[NSNumber numberWithInt:row], [NSNumber numberWithInt:index], NULL]];
+		[pboard declareTypes:[NSArray arrayWithObject:@"PBGitRef"] owner:self];
+		[pboard setData:data forType:@"PBGitRef"];
+	} else {
+		[pboard declareTypes:[NSArray arrayWithObject:NSStringPboardType] owner:self];
+		[pboard setString:[commit shortName] forType:NSStringPboardType];
+	}
+
 	return YES;
 }
 

--- a/Classes/Controllers/PBRefController.m
+++ b/Classes/Controllers/PBRefController.m
@@ -362,7 +362,15 @@
 		[pboard setData:data forType:@"PBGitRef"];
 	} else {
 		[pboard declareTypes:[NSArray arrayWithObject:NSStringPboardType] owner:self];
-		[pboard setString:[commit shortName] forType:NSStringPboardType];
+
+		NSString *info = nil;
+		if (column == [tv columnWithIdentifier:@"ShortSHAColumn"]) {
+			info = [commit shortName];
+		} else {
+			info = [NSString stringWithFormat:@"%@ (%@)", [[commit realSha] substringToIndex:10], [commit subject]];
+		}
+
+		[pboard setString:info forType:NSStringPboardType];
 	}
 
 	return YES;

--- a/Classes/PBCommitList.m
+++ b/Classes/PBCommitList.m
@@ -106,7 +106,12 @@
 	PBGitRevisionCell *cell = (PBGitRevisionCell *)[self preparedCellAtColumn:column row:row];
 	NSRect cellFrame = [self frameOfCellAtColumn:column row:row];
 
-	int index = [cell indexAtX:(location.x - cellFrame.origin.x)];
+	int index = -1;
+
+	if ([cell respondsToSelector:@selector(indexAtX:)]) {
+		index = [cell indexAtX:(location.x - cellFrame.origin.x)];
+	}
+
 	if (index == -1)
 		return [super dragImageForRowsWithIndexes:dragRows tableColumns:tableColumns event:dragEvent offset:dragImageOffset];
 


### PR DESCRIPTION
Now there’s a quick way to stick reference to a commit without losing
your copy pasteboard. Eventually it would be nice if you could use this
to start performing interactive rebasing.
![dragsha](https://cloud.githubusercontent.com/assets/2964/6607609/5cd24670-c7fd-11e4-809d-6e16b3963339.gif)
