### PR TITLE
Closing a repository document leaks everything

### DIFF
--- a/Classes/Controllers/PBGitHistoryController.h
+++ b/Classes/Controllers/PBGitHistoryController.h
@@ -24,33 +24,31 @@
 @class PBHistorySearchController;
 
 @interface PBGitHistoryController : PBViewController {
-	IBOutlet PBRefController *refController;
-	IBOutlet NSSearchField *searchField;
-	IBOutlet NSArrayController* commitController;
-	IBOutlet NSTreeController* treeController;
-	IBOutlet NSOutlineView* fileBrowser;
-	NSArray *currentFileBrowserSelectionPath;
-	IBOutlet PBCommitList* commitList;
-	IBOutlet PBCollapsibleSplitView *historySplitView;
+	IBOutlet NSArrayController *commitController;
+	IBOutlet NSTreeController *treeController;
 	IBOutlet PBWebHistoryController *webHistoryController;
-    QLPreviewPanel* previewPanel;
-	IBOutlet PBHistorySearchController *searchController;
 	IBOutlet GLFileView *fileView;
+	IBOutlet PBRefController *refController;
+	IBOutlet PBHistorySearchController *searchController;
 
-	IBOutlet PBGitGradientBarView *upperToolbarView;
-	IBOutlet NSButton *mergeButton;
-	IBOutlet NSButton *cherryPickButton;
-	IBOutlet NSButton *rebaseButton;
+	__weak IBOutlet NSSearchField *searchField;
+	__weak IBOutlet NSOutlineView *fileBrowser;
+	__weak IBOutlet PBCommitList *commitList;
+	__weak IBOutlet PBCollapsibleSplitView *historySplitView;
+	__weak IBOutlet PBGitGradientBarView *upperToolbarView;
+	__weak IBOutlet NSButton *mergeButton;
+	__weak IBOutlet NSButton *cherryPickButton;
+	__weak IBOutlet NSButton *rebaseButton;
+	__weak IBOutlet PBGitGradientBarView *scopeBarView;
+	__weak IBOutlet NSButton *allBranchesFilterItem;
+	__weak IBOutlet NSButton *localRemoteBranchesFilterItem;
+	__weak IBOutlet NSButton *selectedBranchFilterItem;
+	__weak IBOutlet id webView;
 
-	IBOutlet PBGitGradientBarView *scopeBarView;
-	IBOutlet NSButton *allBranchesFilterItem;
-	IBOutlet NSButton *localRemoteBranchesFilterItem;
-	IBOutlet NSButton *selectedBranchFilterItem;
-
-	IBOutlet id webView;
+	NSArray *currentFileBrowserSelectionPath;
+    QLPreviewPanel* previewPanel;
 	int selectedCommitDetailsIndex;
 	BOOL forceSelectionUpdate;
-	
 	PBGitTree *gitTree;
 	PBGitCommit *webCommit;
 	PBGitCommit *selectedCommit;

--- a/Classes/Controllers/PBGitSidebarController.h
+++ b/Classes/Controllers/PBGitSidebarController.h
@@ -14,11 +14,11 @@
 @class PBGitCommitController;
 
 @interface PBGitSidebarController : PBViewController<NSOutlineViewDelegate> {
-	IBOutlet NSWindow *window;
-	IBOutlet NSOutlineView *sourceView;
-	IBOutlet NSView *sourceListControlsView;
-	IBOutlet NSPopUpButton *actionButton;
-	IBOutlet NSSegmentedControl *remoteControls;
+	__weak IBOutlet NSWindow *window;
+	__weak IBOutlet NSOutlineView *sourceView;
+	__weak IBOutlet NSView *sourceListControlsView;
+	__weak IBOutlet NSPopUpButton *actionButton;
+	__weak IBOutlet NSSegmentedControl *remoteControls;
 
 	NSMutableArray *items;
 

--- a/Classes/Controllers/PBGitWindowController.h
+++ b/Classes/Controllers/PBGitWindowController.h
@@ -15,18 +15,15 @@
 	PBViewController *contentController;
 
 	PBGitSidebarController *sidebarController;
-	IBOutlet NSView *sourceListControlsView;
-	IBOutlet NSSplitView *splitView;
-	IBOutlet NSView *sourceSplitView;
-	IBOutlet NSView *contentSplitView;
+	__weak IBOutlet NSView *sourceListControlsView;
+	__weak IBOutlet NSSplitView *splitView;
+	__weak IBOutlet NSView *sourceSplitView;
+	__weak IBOutlet NSView *contentSplitView;
 
-	IBOutlet NSTextField *statusField;
-	IBOutlet NSProgressIndicator *progressIndicator;
+	__weak IBOutlet NSTextField *statusField;
+	__weak IBOutlet NSProgressIndicator *progressIndicator;
 
 	PBViewController* viewController;
-
-	IBOutlet NSToolbarItem *terminalItem;
-	IBOutlet NSToolbarItem *finderItem;
 }
 
 @property (nonatomic, weak)  PBGitRepository *repository;

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -86,12 +86,6 @@
 	[[statusField cell] setBackgroundStyle:NSBackgroundStyleRaised];
 	[progressIndicator setUsesThreadedAnimation:YES];
 
-	NSImage *finderImage = [[NSWorkspace sharedWorkspace] iconForFileType:NSFileTypeForHFSTypeCode(kFinderIcon)];
-	[finderItem setImage:finderImage];
-
-	NSImage *terminalImage = [[NSWorkspace sharedWorkspace] iconForFile:@"/Applications/Utilities/Terminal.app/"];
-	[terminalItem setImage:terminalImage];
-
 	[self showWindow:nil];
 }
 

--- a/Classes/Controllers/PBHistorySearchController.h
+++ b/Classes/Controllers/PBHistorySearchController.h
@@ -28,13 +28,13 @@ typedef enum historySearchModes {
 	NSPanel *rewindPanel;
 }
 
-@property (assign) IBOutlet PBGitHistoryController *historyController;
-@property (assign) IBOutlet NSArrayController *commitController;
+@property (weak) IBOutlet PBGitHistoryController *historyController;
+@property (weak) IBOutlet NSArrayController *commitController;
 
-@property (assign) IBOutlet NSSearchField *searchField;
-@property (assign) IBOutlet NSSegmentedControl *stepper;
-@property (assign) IBOutlet NSTextField *numberOfMatchesField;
-@property (assign) IBOutlet NSProgressIndicator *progressIndicator;
+@property (weak) IBOutlet NSSearchField *searchField;
+@property (weak) IBOutlet NSSegmentedControl *stepper;
+@property (weak) IBOutlet NSTextField *numberOfMatchesField;
+@property (weak) IBOutlet NSProgressIndicator *progressIndicator;
 
 @property PBHistorySearchMode searchMode;
 

--- a/Classes/Controllers/PBRefController.h
+++ b/Classes/Controllers/PBRefController.h
@@ -16,11 +16,9 @@
 @class PBRefMenuItem;
 
 @interface PBRefController : NSObject <PBRefContextDelegate> {
-	IBOutlet PBGitHistoryController *historyController;
-	IBOutlet NSArrayController *commitController;
-	IBOutlet PBCommitList *commitList;
-
-	IBOutlet NSPopUpButton *branchPopUp;
+	__weak IBOutlet PBGitHistoryController *historyController;
+	__weak IBOutlet NSArrayController *commitController;
+	__weak IBOutlet PBCommitList *commitList;
 }
 
 - (void) fetchRemote:(PBRefMenuItem *)sender;

--- a/Classes/Controllers/PBViewController.h
+++ b/Classes/Controllers/PBViewController.h
@@ -12,7 +12,7 @@
 
 @interface PBViewController : NSViewController {
 	__weak PBGitRepository *repository;
-	PBGitWindowController *superController;
+	__weak PBGitWindowController *superController;
 
 	NSString *status;
 	BOOL isBusy;

--- a/Classes/Controllers/PBWebController.h
+++ b/Classes/Controllers/PBWebController.h
@@ -10,7 +10,7 @@
 #import <WebKit/WebKit.h>
 
 @interface PBWebController : NSObject {
-	IBOutlet WebView* view;
+	__weak IBOutlet WebView* view;
 	NSString *startFile;
 	BOOL finishedLoading;
 
@@ -18,11 +18,11 @@
 	NSMapTable *callbacks;
 
 	// For the repository access
-	IBOutlet id repository;
+	__weak IBOutlet id repository;
 }
 
 @property  NSString *startFile;
-@property  id repository;
+@property (weak) id repository;
 
 - (WebScriptObject *) script;
 - (void) closeView;

--- a/Classes/Controllers/PBWebHistoryController.h
+++ b/Classes/Controllers/PBWebHistoryController.h
@@ -18,8 +18,8 @@
 
 
 @interface PBWebHistoryController : PBWebController {
-	IBOutlet PBGitHistoryController* historyController;
-	IBOutlet id<PBRefContextDelegate> contextMenuDelegate;
+	__weak IBOutlet PBGitHistoryController* historyController;
+	__weak IBOutlet id<PBRefContextDelegate> contextMenuDelegate;
 
 	GTOID* currentSha;
 	NSString* diff;

--- a/Classes/PBCommitList.h
+++ b/Classes/PBCommitList.h
@@ -16,10 +16,10 @@
 typedef void(^PBFindPanelActionBlock)(id sender);
 
 @interface PBCommitList : NSTableView {
-	IBOutlet WebView* webView;
-	IBOutlet PBWebHistoryController *webController;
-	IBOutlet PBGitHistoryController *controller;
-	IBOutlet PBHistorySearchController *searchController;
+	__weak IBOutlet WebView* webView;
+	__weak IBOutlet PBWebHistoryController *webController;
+	__weak IBOutlet PBGitHistoryController *controller;
+	__weak IBOutlet PBHistorySearchController *searchController;
 
     BOOL useAdjustScroll;
 	NSPoint mouseDownPoint;

--- a/Classes/Views/GLFileView.h
+++ b/Classes/Views/GLFileView.h
@@ -14,12 +14,12 @@
 @class PBGitHistoryController;
 
 @interface GLFileView : PBWebController <MGScopeBarDelegate> {
-	IBOutlet PBGitHistoryController* historyController;
-	IBOutlet MGScopeBar *typeBar;
+	__weak IBOutlet PBGitHistoryController* historyController;
+	__weak IBOutlet MGScopeBar *typeBar;
 	NSMutableArray *groups;
 	NSString *logFormat;
-	IBOutlet NSView *accessoryView;
-	IBOutlet NSSplitView *fileListSplitView;
+	__weak IBOutlet NSView *accessoryView;
+	__weak IBOutlet NSSplitView *fileListSplitView;
 }
 
 - (void)showFile;

--- a/Classes/Views/PBGitRevisionCell.h
+++ b/Classes/Views/PBGitRevisionCell.h
@@ -16,8 +16,8 @@
 	PBGitCommit *objectValue;
 	PBGraphCellInfo *cellInfo;
 	NSTextFieldCell *textCell;
-	IBOutlet PBGitHistoryController *controller;
-	IBOutlet id<PBRefContextDelegate> contextMenuDelegate;
+	__weak IBOutlet PBGitHistoryController *controller;
+	__weak IBOutlet id<PBRefContextDelegate> contextMenuDelegate;
 }
 
 - (int) indexAtX:(float)x;

--- a/Classes/Views/PBQLOutlineView.h
+++ b/Classes/Views/PBQLOutlineView.h
@@ -10,7 +10,7 @@
 #import "PBGitHistoryController.h"
 
 @interface PBQLOutlineView : NSOutlineView {
-	IBOutlet PBGitHistoryController* controller;
+	__weak IBOutlet PBGitHistoryController* controller;
 }
 
 @end

--- a/Classes/Views/PBQLTextView.h
+++ b/Classes/Views/PBQLTextView.h
@@ -13,7 +13,7 @@
 
 
 @interface PBQLTextView : NSTextView {
-	IBOutlet PBGitHistoryController *controller;
+	__weak IBOutlet PBGitHistoryController *controller;
 }
 
 @end

--- a/Classes/git/PBGitHistoryGrapher.h
+++ b/Classes/git/PBGitHistoryGrapher.h
@@ -17,7 +17,7 @@
 
 
 @interface PBGitHistoryGrapher : NSObject {
-	id delegate;
+	__weak id delegate;
 	NSOperationQueue *currentQueue;
 
 	NSMutableSet *searchSHAs;

--- a/Classes/git/PBGitHistoryGrapher.m
+++ b/Classes/git/PBGitHistoryGrapher.m
@@ -30,7 +30,8 @@
 - (void)sendCommits:(NSArray *)commits
 {
 	NSDictionary *commitData = [NSDictionary dictionaryWithObjectsAndKeys:currentQueue, kCurrentQueueKey, commits, kNewCommitsKey, nil];
-	[delegate performSelectorOnMainThread:@selector(updateCommitsFromGrapher:) withObject:commitData waitUntilDone:NO];
+	id strongDelegate = delegate;
+	[strongDelegate performSelectorOnMainThread:@selector(updateCommitsFromGrapher:) withObject:commitData waitUntilDone:NO];
 }
 
 
@@ -39,6 +40,7 @@
 	if (!revList || [revList count] == 0)
 		return;
 
+	id strongDelegate = delegate;
 	//NSDate *start = [NSDate date];
 	NSThread *currentThread = [NSThread currentThread];
 	NSDate *lastUpdate = [NSDate date];
@@ -69,7 +71,7 @@
 	//NSLog(@"Graphed %i commits in %f seconds (%f/sec)", counter, duration, counter/duration);
 
 	[self sendCommits:commits];
-	[delegate performSelectorOnMainThread:@selector(finishedGraphing) withObject:nil waitUntilDone:NO];
+	[strongDelegate performSelectorOnMainThread:@selector(finishedGraphing) withObject:nil waitUntilDone:NO];
 }
 
 

--- a/Classes/git/PBGitHistoryList.m
+++ b/Classes/git/PBGitHistoryList.m
@@ -92,6 +92,7 @@
 	if (currentRevList) {
 		[currentRevList removeObserver:self forKeyPath:@"commits"];
 		[currentRevList cancel];
+		currentRevList = nil;
 	}
 	[graphQueue cancelAllOperations];
 


### PR DESCRIPTION
Closing a repository's window doesn't return any memory to the system. It looks like there's retain cycles everywhere.

This branch doesn't yet eliminate all leaks but fixes some big ones.
